### PR TITLE
pass secrets as inputs to reusable workflow

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-function.yml
+++ b/.github/workflows/build-deploy-cloudrun-function.yml
@@ -19,4 +19,7 @@ jobs:
     uses: CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@gcp-cloudrun #temporarily using branch for testing
     with:
       function_name: ${{ github.event.inputs.function_name }}
+      workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      region: ${{ secrets.GCP_REGION }}
 


### PR DESCRIPTION
Fix error: 
```
Run google-github-actions/auth@v2 Error: google-github-actions/auth failed with: the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"! If you are specifying input values via GitHub secrets, ensure the secret is being injected into the environment. By default, secrets are not passed to workflows triggered from forks, including Dependabot.
```