### PR TITLE
fix issue with secrets

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-function.yml
+++ b/.github/workflows/build-deploy-cloudrun-function.yml
@@ -15,11 +15,23 @@ on:
         default: 'fivetran-trigger'
 
 jobs:
-  build_and_deploy:
-    uses: CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@gcp-cloudrun #temporarily using branch for testing
-    with:
-      function_name: ${{ github.event.inputs.function_name }}
-      workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-      region: ${{ secrets.GCP_REGION }}
+  build-and-deploy:
+    runs-on: ubuntu-latest
 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Call build-deploy-cloudrun-function workflow
+        uses: CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@gcp-cloudrun
+        with:
+          function_name: ${{ github.event.inputs.function_name }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          region: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
Correct issue where the context of the secret is not recognized in the with a section of the jobs.build_and_deploy step. This is because the use keyword does not support the secrets context directly. Instead, pass the secrets as inputs to the called workflow.