### PR TITLE
revert last commit

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-function.yml
+++ b/.github/workflows/build-deploy-cloudrun-function.yml
@@ -15,23 +15,12 @@ on:
         default: 'fivetran-trigger'
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
+  build_and_deploy:
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    uses: CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@gcp-cloudrun #temporarily using branch for testing
+    with:
+      function_name: ${{ github.event.inputs.function_name }}
+      workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+      service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      region: ${{ secrets.GCP_REGION }}
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-      - name: Call build-deploy-cloudrun-function workflow
-        uses: CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@gcp-cloudrun
-        with:
-          function_name: ${{ github.event.inputs.function_name }}
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          region: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
[Error](https://github.com/CruGlobal/dot/actions/runs/11503404377/workflow)
reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps