### PR TITLE
Add dbt-trigger and tests

### DIFF
--- a/dbt-trigger/dbt_client.py
+++ b/dbt-trigger/dbt_client.py
@@ -1,0 +1,40 @@
+import os
+import logging
+import requests
+
+logger = logging.getLogger("primary_logger")
+
+
+class DbtClient:
+
+    def __init__(self, access_token: str, account_id: str):
+        self.access_token = access_token
+        self.account_id = account_id
+        self.headers = {"Authorization": f"Bearer {access_token}"}
+        self.account_url = f"https://cloud.getdbt.com/api/v2/accounts/{account_id}/"
+        self.base_url = "https://cloud.getdbt.com/api/v2/"
+
+    def _request(self, url, data=None, params=None, method="GET"):
+        request_details = {"headers": self.headers}
+        if data:
+            request_details["data"] = data
+        if params:
+            request_details["params"] = params
+
+        try:
+            response = requests.request(method, url, **request_details)
+            if response.ok:
+                return response.json()
+        except Exception as e:
+            logger.exception(f"Error in making request to {url}: {e}")
+            raise
+
+    def trigger_job(self, job_id):
+        logger.info(f"Triggering dbt job {job_id} on account {self.account_id}")
+
+        response = self._request(
+            f"{self.account_url}/jobs/{job_id}/run/",
+            data={"cause": f"Triggered by Google Cloud Function"},
+            method="POST",
+        )
+        return response

--- a/dbt-trigger/dbt_client.py
+++ b/dbt-trigger/dbt_client.py
@@ -11,8 +11,8 @@ class DbtClient:
         self.access_token = access_token
         self.account_id = account_id
         self.headers = {"Authorization": f"Bearer {access_token}"}
-        self.account_url = f"https://cloud.getdbt.com/api/v2/accounts/{account_id}/"
-        self.base_url = "https://cloud.getdbt.com/api/v2/"
+        self.account_url = f"https://cloud.getdbt.com/api/v2/accounts/{account_id}"
+        self.base_url = "https://cloud.getdbt.com/api/v2"
 
     def _request(self, url, data=None, params=None, method="GET"):
         request_details = {"headers": self.headers}

--- a/dbt-trigger/main.py
+++ b/dbt-trigger/main.py
@@ -1,0 +1,116 @@
+import os
+import functions_framework
+from dbt_client import DbtClient
+import logging
+import sys
+import os
+import json
+from requests import auth, Session
+import time
+
+
+logger = logging.getLogger("primary_logger")
+logger.propagate = False
+
+
+class CloudLoggingFormatter(logging.Formatter):
+    """
+    Produces messages compatible with google cloud logging
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        s = super().format(record)
+        return json.dumps(
+            {
+                "message": s,
+                "severity": record.levelname,
+                "timestamp": {"seconds": int(record.created), "nanos": 0},
+            }
+        )
+
+
+def setup_logging():
+    """
+    Sets up logging for the application.
+    """
+    global logger
+
+    # Remove any existing handlers
+    if logger.handlers:
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = CloudLoggingFormatter(fmt="%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    sys.excepthook = handle_unhandled_exception
+
+
+def handle_unhandled_exception(exc_type, exc_value, exc_traceback):
+    """
+    Handles unhandled exceptions by logging the exception details and sending an alert to the development team.
+
+    This function is intended to be used as a custom excepthook function, which is called when an unhandled exception
+    occurs in the application. The function logs the exception details to the primary logger, and sends an alert to
+    the development team using a third-party service such as Datadog or PagerDuty.
+
+    Args:
+        exc_type (type): The type of the exception that was raised.
+        exc_value (Exception): The exception object that was raised.
+        exc_traceback (traceback): The traceback object that was generated when the exception was raised.
+    """
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logger.exception(
+        "Unhandled exception", exc_info=(exc_type, exc_value, exc_traceback)
+    )
+
+
+@functions_framework.http
+def trigger_dbt_job(request):
+    """
+    Triggers a dbt job for a given job id.
+
+    """
+    setup_logging()
+
+    request_json = request.get_json(silent=True)
+
+    if (
+        request_json is None
+        and request.headers.get("Content-Type") == "application/octet-stream"
+    ):
+        try:
+            request_data = request.get_data(as_text=True)
+            request_json = json.loads(request_data) if request_data else None
+        except Exception as e:
+            logger.exception(f"Failed to parse octet-stream data: {str(e)}")
+            request_json = None
+
+    if request_json and "job_id" in request_json:
+        job_id = request_json["job_id"]
+    else:
+        logger.exception("Failed to retrieve job_id")
+        raise
+
+    dbt_token = os.environ["DBT_TOKEN"]
+    account_id = "10206"
+    try:
+        client = DbtClient(access_token=dbt_token, account_id=account_id)
+        job_run_response = client.trigger_job(job_id)
+        run_id = job_run_response["data"]["id"]
+        if run_id is None:
+            logger.exception(f"dbt run failed to start.")
+            return
+        logger.info(f"DBT run {run_id} started successfully.")
+        return "Trigger dbt job completed", 200
+    except Exception as e:
+        logger.exception(
+            f"An error occurred when attempting to trigger dbt job: {str(e)}"
+        )
+        raise

--- a/dbt-trigger/main_test.py
+++ b/dbt-trigger/main_test.py
@@ -1,0 +1,155 @@
+import pytest
+import responses
+import logging
+import sys
+from unittest import mock
+from flask import Request
+import main
+import requests
+
+
+@pytest.fixture
+def mock_env_vars(monkeypatch):
+    monkeypatch.setenv("DBT_TOKEN", "test_dbt_token")
+
+
+@pytest.fixture
+def mock_request_with_job_id():
+    mock_req = mock.Mock(spec=Request)
+    mock_req.get_json.return_value = {"job_id": "test_job_id"}
+    return mock_req
+
+
+@pytest.fixture
+def mock_request_without_job_id():
+    mock_req = mock.Mock(spec=Request)
+    mock_req.get_json.return_value = {}
+    return mock_req
+
+
+@pytest.fixture(autouse=True)
+def setup_logging():
+    """Set up logging for tests using the same configuration as main.py"""
+    logger = logging.getLogger("primary_logger")
+    logger.handlers = []
+    logger.propagate = True
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = main.CloudLoggingFormatter(fmt="%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    yield
+
+    logger.handlers = []
+    logger.propagate = False
+
+
+@responses.activate
+def test_trigger_dbt_job_success(mock_env_vars, mock_request_with_job_id, caplog):
+    """
+    Tests the trigger_dbt_job function when the job is triggered successfully.
+    """
+    responses.add(
+        responses.POST,
+        "https://cloud.getdbt.com/api/v2/accounts/10206/jobs/test_job_id/run/",
+        json={"data": {"id": "test_run_id"}},
+        status=200,
+    )
+
+    response = main.trigger_dbt_job(mock_request_with_job_id)
+
+    success_message = "DBT run test_run_id started successfully."
+    log_messages = [record.message for record in caplog.records]
+    assert any(
+        success_message in msg for msg in log_messages
+    ), f"Expected message not found in logs: {log_messages}"
+    assert response[0] == "Trigger dbt job completed"
+    assert response[1] == 200
+
+
+@responses.activate
+def test_trigger_dbt_job_missing_job_id(
+    mock_env_vars, mock_request_without_job_id, caplog
+):
+    """
+    Tests the trigger_dbt_job function when job_id is missing from request.
+    """
+    try:
+        main.trigger_dbt_job(mock_request_without_job_id)
+        pytest.fail("Expected function to raise an exception")
+    except Exception as e:
+        log_messages = [record.message for record in caplog.records]
+        assert any(
+            "Failed to retrieve job_id" in msg for msg in log_messages
+        ), f"Expected error message not found in logs: {log_messages}"
+
+
+@responses.activate
+def test_trigger_dbt_job_invalid_credentials(
+    mock_env_vars, mock_request_with_job_id, caplog
+):
+    """
+    Tests the trigger_dbt_job function with invalid API credentials.
+    """
+    responses.add(
+        responses.POST,
+        "https://cloud.getdbt.com/api/v2/accounts/10206/jobs/test_job_id/run/",
+        status=401,
+        json={"message": "Invalid API key"},
+    )
+
+    try:
+        main.trigger_dbt_job(mock_request_with_job_id)
+        pytest.fail("Expected function to raise an exception")
+    except Exception as e:
+        log_messages = [record.message for record in caplog.records]
+        error_message = "An error occurred when attempting to trigger dbt job"
+        assert any(
+            error_message in msg for msg in log_messages
+        ), f"Expected error message not found in logs: {log_messages}"
+
+
+@responses.activate
+def test_trigger_dbt_job_server_error(mock_env_vars, mock_request_with_job_id, caplog):
+    """
+    Tests the trigger_dbt_job function when the server returns a 500 error.
+    """
+    responses.add(
+        responses.POST,
+        "https://cloud.getdbt.com/api/v2/accounts/10206/jobs/test_job_id/run/",
+        status=500,
+        json={"message": "Internal Server Error"},
+    )
+
+    try:
+        main.trigger_dbt_job(mock_request_with_job_id)
+        pytest.fail("Expected function to raise an exception")
+    except Exception as e:
+        log_messages = [record.message for record in caplog.records]
+        error_message = "An error occurred when attempting to trigger dbt job"
+        assert any(
+            error_message in msg for msg in log_messages
+        ), f"Expected error message not found in logs: {log_messages}"
+
+
+@responses.activate
+def test_trigger_dbt_job_timeout(mock_env_vars, mock_request_with_job_id, caplog):
+    """
+    Tests the trigger_dbt_job function when the request times out.
+    """
+    responses.add(
+        responses.POST,
+        "https://cloud.getdbt.com/api/v2/accounts/10206/jobs/test_job_id/run/",
+        body=requests.exceptions.ConnectTimeout("Connection timed out"),
+    )
+
+    try:
+        main.trigger_dbt_job(mock_request_with_job_id)
+        pytest.fail("Expected function to raise an exception")
+    except Exception as e:
+        log_messages = [record.message for record in caplog.records]
+        assert any(
+            "Error in making request" in msg for msg in log_messages
+        ), f"Expected error message not found in logs: {log_messages}"

--- a/dbt-trigger/requirements-test.txt
+++ b/dbt-trigger/requirements-test.txt
@@ -1,0 +1,5 @@
+flask==3.0.3
+pytest==8.2.0
+pytest-mock==3.14.0
+requests==2.31.0
+responses==0.23.1

--- a/dbt-trigger/requirements.txt
+++ b/dbt-trigger/requirements.txt
@@ -1,0 +1,5 @@
+# For basic Cloud Run Functions infrastructure
+functions-framework==3.*
+
+# For fivetran api calls
+requests==2.32.3

--- a/poc-terraform/main.tf
+++ b/poc-terraform/main.tf
@@ -1,10 +1,10 @@
-module "fivetran-triggers" {
-  # TODO: use this when published; git@github.com:CruGlobal/cru-terraform-modules.git//gcp/cloudrun-function/scheduled-tasks?ref={{version-tag}}
-  source      = "git::https://github.com/CruGlobal/cru-terraform-modules.git//gcp/cloudrun-function/scheduled-tasks?ref=v30.13.0"
+module "fivetran_trigger" {
+  source = "git::https://github.com/CruGlobal/cru-terraform-modules.git//gcp/cloudrun-function/scheduled-tasks?ref=v30.14.4"
+
   name        = "fivetran-trigger"
   description = "A set of triggers to kick off Fivetran connection syncs for various systems"
-  secrets     = ["API_KEY", "API_SECRET"]
-  time_zone   = "UTC"
+
+  time_zone = "UTC"
   schedule = {
     el_fivetran_logs : {
       cron : "0 0 1 1 *",
@@ -13,6 +13,9 @@ module "fivetran-triggers" {
       }
     }
   }
+
+  secrets = ["API_KEY", "API_SECRET"]
+
   secret_managers = [
     "user:luis.rodriguez@cru.org",
     "user:matt.drees@cru.org",
@@ -21,5 +24,37 @@ module "fivetran-triggers" {
   project_id = local.project_id
 }
 
+module "dbt-triggers" {
+  source      = "git::https://github.com/CruGlobal/cru-terraform-modules.git//gcp/cloudrun-function/scheduled-tasks?ref=v30.14.4"
+  name        = "dbt-trigger"
+  description = "A set of triggers to kick off dbt jobs"
+  time_zone   = "UTC"
+  schedule = {
+    utilities : {
+      cron : "0 0 1 1 *",
+      argument = {
+        "job_id" = "23366"
+      }
+    }
+  }
 
+  secrets = ["DBT_TOKEN"]
 
+  secret_managers = [
+    "user:luis.rodriguez@cru.org",
+    "user:matt.drees@cru.org",
+
+    
+          
+            
+    
+
+          
+          Expand Down
+    
+    
+  
+    "group:dps-gcp-role-data-engineers@cru.org",
+  ]
+  project_id = local.project_id
+}

--- a/poc-terraform/main.tf
+++ b/poc-terraform/main.tf
@@ -43,17 +43,6 @@ module "dbt-triggers" {
   secret_managers = [
     "user:luis.rodriguez@cru.org",
     "user:matt.drees@cru.org",
-
-    
-          
-            
-    
-
-          
-          Expand Down
-    
-    
-  
     "group:dps-gcp-role-data-engineers@cru.org",
   ]
   project_id = local.project_id


### PR DESCRIPTION
Add a dbt-trigger to enable triggering a dbt job run by invoking this Google Cloud Function. This function will only initiate the dbt job run and will not wait for its completion.