### PR TITLE
Genericize dbt-webhook, add CI tests, auto-merge Dependabot

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,24 @@
+name: Auto-merge Dependabot
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: metadata
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,7 @@ jobs:
           for dir in */; do
             dir="${dir%/}"
             if echo "$CHANGED" | grep -q "^${dir}/" && [ -f "${dir}/main_test.py" ]; then
-              FUNCTIONS=$(echo "$FUNCTIONS" | jq --arg d "$dir" '. + [$d]')
+              FUNCTIONS=$(echo "$FUNCTIONS" | jq -c --arg d "$dir" '. + [$d]')
             fi
           done
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,71 @@
+name: Run Tests
+
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '**/requirements*.txt'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.py'
+      - '**/requirements*.txt'
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      functions: ${{ steps.changed.outputs.functions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed functions with tests
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED=$(git diff --name-only HEAD~1)
+          fi
+
+          FUNCTIONS='[]'
+          for dir in dbt-trigger dbt-webhook fivetran-trigger okta-sync process-geography woo-sync; do
+            if echo "$CHANGED" | grep -q "^${dir}/" && [ -f "${dir}/main_test.py" ]; then
+              FUNCTIONS=$(echo "$FUNCTIONS" | jq --arg d "$dir" '. + [$d]')
+            fi
+          done
+
+          echo "functions=$FUNCTIONS" >> "$GITHUB_OUTPUT"
+          echo "Will test: $FUNCTIONS"
+
+  test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.functions != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        function: ${{ fromJson(needs.detect-changes.outputs.functions) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          cd ${{ matrix.function }}
+          pip install -r requirements.txt
+          if [ -f requirements-test.txt ]; then
+            pip install -r requirements-test.txt
+          else
+            pip install pytest pytest-mock flask
+          fi
+
+      - name: Run tests
+        run: |
+          cd ${{ matrix.function }}
+          pytest -v main_test.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,11 +27,12 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           else
-            CHANGED=$(git diff --name-only HEAD~1)
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
           fi
 
           FUNCTIONS='[]'
-          for dir in dbt-trigger dbt-webhook fivetran-trigger okta-sync process-geography woo-sync; do
+          for dir in */; do
+            dir="${dir%/}"
             if echo "$CHANGED" | grep -q "^${dir}/" && [ -f "${dir}/main_test.py" ]; then
               FUNCTIONS=$(echo "$FUNCTIONS" | jq --arg d "$dir" '. + [$d]')
             fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,13 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           else
-            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            BEFORE="${{ github.event.before }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              # First push to branch — compare against parent commit
+              CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git show --name-only --pretty="" HEAD)
+            else
+              CHANGED=$(git diff --name-only "$BEFORE" "${{ github.sha }}")
+            fi
           fi
 
           FUNCTIONS='[]'
@@ -69,4 +75,4 @@ jobs:
       - name: Run tests
         run: |
           cd ${{ matrix.function }}
-          pytest -v main_test.py
+          pytest -v

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ gcloud functions deploy fivetran-trigger --source=. --entry-point=hello_http --r
 ```
 
 
+## Environments
+
+| Environment | GCP Project | Code Branch | Purpose |
+|-------------|------------|-------------|---------|
+| **prod** | `cru-data-orchestration-prod` | `main` | All production AND staging data pipelines. This is where all real orchestration runs. |
+| **stage** | `cru-data-orchestration-stage` | `staging` | Infrastructure health check only. Not used for data pipelines. |
+| **poc** | `cru-data-orchestration-poc` | `poc` | Developer sandbox for testing new functions and workflows. |
+
+All data pipelines — including those that process staging source data — are orchestrated from the
+**prod** project. The prod environment routes to the correct dbt Cloud jobs and environments based on
+job IDs and configuration. The stage project does not run data pipelines.
+
+Terraform for prod and stage is managed via Atlantis in the
+[cru-terraform repo](https://github.com/CruGlobal/cru-terraform/tree/master/applications/data-warehouse/dot).
+
 ## POC environment infrastructure
 
 The POC environment is contained within the [cru-data-orchestration-poc](https://console.cloud.google.com/welcome?project=cru-data-orchestration-poc) GCP project.

--- a/dbt-webhook/conftest.py
+++ b/dbt-webhook/conftest.py
@@ -1,21 +1,34 @@
 """
-Mock GCP credentials and Pub/Sub client before main.py is imported.
-The PublisherClient() is instantiated at module level in main.py,
-which requires GCP credentials. This conftest patches it before any
-test module imports main.
+Pytest configuration for dbt-webhook tests.
+
+The PublisherClient is instantiated at module level in main.py, which requires
+GCP credentials. This conftest patches it before main.py is imported so tests
+can run locally without credentials.
+
+Each topic gets a distinct mock path so tests can verify routing correctness
+(e.g., success events go to the completed topic, not the retry topic).
 """
 import sys
 from unittest import mock
 
-# Patch the Pub/Sub client before main.py is imported
+
+def mock_topic_path(project, topic_name):
+    """Return a distinct mock path per topic so routing assertions are meaningful."""
+    return f"projects/{project}/topics/{topic_name}"
+
+
 mock_publisher = mock.MagicMock()
-mock_publisher.topic_path.return_value = "projects/test-project/topics/mock-topic"
+mock_publisher.topic_path.side_effect = mock_topic_path
 
 with mock.patch.dict(
     "os.environ",
     {"GOOGLE_CLOUD_PROJECT": "test-project", "DBT_WEBHOOK_SECRET": "test-secret"},
 ):
-    with mock.patch("google.cloud.pubsub_v1.PublisherClient", return_value=mock_publisher):
+    with mock.patch(
+        "google.cloud.pubsub_v1.PublisherClient", return_value=mock_publisher
+    ):
+        # Clear cached module so it re-imports with mocked credentials.
+        # Necessary for pytest-watch or other re-run-in-same-process tools.
         if "main" in sys.modules:
             del sys.modules["main"]
         import main

--- a/dbt-webhook/conftest.py
+++ b/dbt-webhook/conftest.py
@@ -1,0 +1,21 @@
+"""
+Mock GCP credentials and Pub/Sub client before main.py is imported.
+The PublisherClient() is instantiated at module level in main.py,
+which requires GCP credentials. This conftest patches it before any
+test module imports main.
+"""
+import sys
+from unittest import mock
+
+# Patch the Pub/Sub client before main.py is imported
+mock_publisher = mock.MagicMock()
+mock_publisher.topic_path.return_value = "projects/test-project/topics/mock-topic"
+
+with mock.patch.dict(
+    "os.environ",
+    {"GOOGLE_CLOUD_PROJECT": "test-project", "DBT_WEBHOOK_SECRET": "test-secret"},
+):
+    with mock.patch("google.cloud.pubsub_v1.PublisherClient", return_value=mock_publisher):
+        if "main" in sys.modules:
+            del sys.modules["main"]
+        import main

--- a/dbt-webhook/main.py
+++ b/dbt-webhook/main.py
@@ -1,14 +1,52 @@
+"""
+dbt Cloud Webhook Handler — Generic Event Publisher
+
+Receives webhook notifications from dbt Cloud when jobs complete.
+Publishes events to Pub/Sub topics for downstream workflow consumption.
+
+Event routing:
+  - Successful completions → dbt-job-completed topic (all downstream workflows)
+  - Failed completions → dbt-retry-events topic (automatic retry workflow)
+
+The dbt-job-completed topic is the generic fan-out point for all post-dbt
+orchestration. Downstream workflows (Fabric, Hightouch, etc.) subscribe with
+Pub/Sub attribute filters on job_id and act independently. Adding a new
+downstream integration requires only a Terraform change (new subscription +
+workflow), not a code change here.
+
+Legacy: Successful completions for jobs with a Fabric mapping also publish
+to the fabric-job-events topic for backward compatibility. This will be
+removed after the Fabric workflow migrates to the dbt-job-completed topic.
+
+Related:
+  - Terraform: cru-terraform/applications/data-warehouse/dot/prod/
+  - Design: ~/dotfiles/design-docs/design-netsuite-hightouch-orchestration.md
+  - Jira: DT-495
+"""
+
 import functions_framework
 import os
 import logging
 import sys
 import json
 from google.cloud import pubsub_v1
-from webhook_utils import verify_dbt_signature, parse_dbt_webhook, map_dbt_to_fabric, create_fabric_job_message
+from webhook_utils import (
+    verify_dbt_signature,
+    parse_dbt_webhook,
+    map_dbt_to_fabric,
+    create_fabric_job_message,
+)
 
 logger = logging.getLogger("primary_logger")
 logger.propagate = False
+
 gcp_project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", None)
+if not gcp_project_id:
+    raise EnvironmentError(
+        "GOOGLE_CLOUD_PROJECT environment variable is required. "
+        "Set it to the GCP project ID where Pub/Sub topics are created."
+    )
+
 dbt_webhook_secret = os.environ.get("DBT_WEBHOOK_SECRET", None)
 publisher = pubsub_v1.PublisherClient()
 completed_topic_path = publisher.topic_path(gcp_project_id, "dbt-job-completed")
@@ -17,9 +55,7 @@ retry_topic_path = publisher.topic_path(gcp_project_id, "dbt-retry-events")
 
 
 class CloudLoggingFormatter(logging.Formatter):
-    """
-    Produces messages compatible with google cloud logging
-    """
+    """Formats log records as JSON for Google Cloud Logging."""
 
     def format(self, record: logging.LogRecord) -> str:
         s = super().format(record)
@@ -60,8 +96,11 @@ def handle_unhandled_exception(exc_type, exc_value, exc_traceback):
 
 def create_completion_message(dbt_info: dict) -> dict:
     """
-    Create a generic dbt job completion message for the dbt-job-completed topic.
-    Downstream workflows filter by job_id via Pub/Sub attribute filters.
+    Build the message payload for the dbt-job-completed Pub/Sub topic.
+
+    This message is consumed by all downstream workflows. Include every field
+    that any consumer might need — adding fields later requires coordinating
+    with all subscribers.
     """
     return {
         "job_id": dbt_info.get("job_id", ""),
@@ -69,6 +108,7 @@ def create_completion_message(dbt_info: dict) -> dict:
         "run_id": dbt_info.get("run_id", ""),
         "run_status": dbt_info.get("run_status", ""),
         "run_status_code": dbt_info.get("run_status_code", ""),
+        "run_status_humanized": dbt_info.get("run_status_humanized", ""),
         "environment_id": dbt_info.get("environment_id", ""),
         "account_id": dbt_info.get("account_id", ""),
         "event_type": dbt_info.get("event_type", ""),
@@ -77,7 +117,10 @@ def create_completion_message(dbt_info: dict) -> dict:
 
 def create_retry_message(dbt_info: dict) -> dict:
     """
-    Create a retry event message for a failed dbt job.
+    Build the message payload for the dbt-retry-events Pub/Sub topic.
+
+    The attempt_number starts at 0 here. The dbt-retry-workflow increments it
+    on each retry attempt and re-publishes if retries are exhausted.
     """
     return {
         "job_id": dbt_info.get("job_id", ""),
@@ -93,9 +136,12 @@ def create_retry_message(dbt_info: dict) -> dict:
 
 def handle_job_success(dbt_info: dict) -> tuple:
     """
-    Publish successful completion to the generic dbt-job-completed topic.
-    Also publishes to legacy fabric-job-events topic if there's a Fabric mapping
-    (backward compatibility — will be removed after Fabric migrates to the new topic).
+    Publish successful completion to the generic dbt-job-completed topic,
+    then optionally to the legacy fabric-job-events topic if there's a mapping.
+
+    The Fabric publish is isolated in its own try/except so a Fabric failure
+    does not cause a 500 response or trigger a dbt Cloud webhook retry (which
+    would duplicate the message on dbt-job-completed).
     """
     completion_message = create_completion_message(dbt_info)
 
@@ -108,41 +154,49 @@ def handle_job_success(dbt_info: dict) -> tuple:
             message_bytes,
             job_id=dbt_info.get("job_id", ""),
             run_status=dbt_info.get("run_status", ""),
+            environment_id=dbt_info.get("environment_id", ""),
         )
-        message_id = future.result()
+        message_id = future.result(timeout=10)
 
         logger.info(
             f"Published dbt job completion to Pub/Sub: message_id={message_id}, "
             f"job_id={dbt_info.get('job_id')}, job_name={dbt_info.get('job_name')}"
         )
 
-        # Legacy: also publish to fabric-job-events if this job has a Fabric mapping.
-        # Remove this block after Fabric workflow migrates to dbt-job-completed topic.
-        fabric_config = map_dbt_to_fabric(dbt_info.get("job_id", ""))
-        if fabric_config:
+    except Exception as e:
+        logger.exception(f"Error publishing to dbt-job-completed: {str(e)}")
+        return (f"Error publishing to Pub/Sub: {str(e)}", 500)
+
+    # Legacy: also publish to fabric-job-events if this job has a Fabric mapping.
+    # This block is isolated so a Fabric failure does not affect the primary
+    # publish result or trigger a webhook retry.
+    # Remove this block after Fabric workflow migrates to dbt-job-completed topic.
+    fabric_config = map_dbt_to_fabric(dbt_info.get("job_id", ""))
+    if fabric_config:
+        try:
             fabric_message = create_fabric_job_message(fabric_config, dbt_info)
             fabric_bytes = json.dumps(fabric_message).encode("utf-8")
             fabric_future = publisher.publish(fabric_topic_path, fabric_bytes)
-            fabric_msg_id = fabric_future.result()
+            fabric_msg_id = fabric_future.result(timeout=10)
             logger.info(
                 f"Published to legacy fabric-job-events: message_id={fabric_msg_id}, "
                 f"workspace_id={fabric_config['workspace_id']}"
             )
+        except Exception as e:
+            logger.exception(
+                f"Error publishing to legacy fabric-job-events (non-fatal): {str(e)}"
+            )
 
-        return (
-            {
-                "status": "success",
-                "message": "Job completion published to dbt-job-completed topic",
-                "message_id": message_id,
-                "dbt_job_id": dbt_info.get("job_id"),
-                "dbt_run_id": dbt_info.get("run_id"),
-            },
-            200,
-        )
-
-    except Exception as e:
-        logger.exception(f"Error publishing to Pub/Sub: {str(e)}")
-        return (f"Error publishing to Pub/Sub: {str(e)}", 500)
+    return (
+        {
+            "status": "success",
+            "message": "Job completion published to dbt-job-completed topic",
+            "message_id": message_id,
+            "dbt_job_id": dbt_info.get("job_id"),
+            "dbt_run_id": dbt_info.get("run_id"),
+        },
+        200,
+    )
 
 
 def handle_job_failure(dbt_info: dict) -> tuple:
@@ -159,8 +213,13 @@ def handle_job_failure(dbt_info: dict) -> tuple:
         message_json = json.dumps(retry_message)
         message_bytes = message_json.encode("utf-8")
 
-        future = publisher.publish(retry_topic_path, message_bytes)
-        message_id = future.result()
+        future = publisher.publish(
+            retry_topic_path,
+            message_bytes,
+            job_id=dbt_info.get("job_id", ""),
+            run_status=dbt_info.get("run_status", ""),
+        )
+        message_id = future.result(timeout=10)
 
         logger.info(
             f"Published retry event to Pub/Sub: message_id={message_id}, "
@@ -186,11 +245,16 @@ def handle_job_failure(dbt_info: dict) -> tuple:
 @functions_framework.http
 def webhook_handler(request):
     """
-    Generic dbt Cloud webhook handler.
-    Publishes all successful completions to dbt-job-completed topic with job_id
-    as a message attribute. Downstream workflows (Fabric, Hightouch, etc.)
-    subscribe with attribute filters and act independently.
-    Publishes failures to dbt-retry-events topic for automatic retry.
+    HTTP Cloud Function entry point for dbt Cloud webhooks.
+
+    Receives job completion notifications and routes them:
+      - Success → dbt-job-completed topic (+ legacy fabric-job-events if mapped)
+      - Failure → dbt-retry-events topic
+      - Cancelled/other → logged and ignored (200 response)
+
+    dbt Cloud sends webhooks with JWT Bearer tokens in the Authorization header.
+    The dbt Cloud webhook should be configured at the account level with an empty
+    job list so ALL job completions are received.
     """
     setup_logging()
 
@@ -214,7 +278,6 @@ def webhook_handler(request):
             return ("Invalid JSON", 400)
 
         dbt_info = parse_dbt_webhook(request_json)
-        logger.info(f"Parsed DBT info: {dbt_info}")
         if not dbt_info:
             logger.error("Failed to parse DBT webhook payload")
             return ("Invalid DBT webhook payload", 400)
@@ -231,6 +294,8 @@ def webhook_handler(request):
             )
             return ("Event ignored - not a job completion", 200)
 
+        # Route by status. Status code is authoritative; string is a fallback
+        # for resilience in case the payload format changes.
         run_status_code = dbt_info.get("run_status_code")
 
         if run_status_code == 20 or dbt_info.get("run_status") == "Error":

--- a/dbt-webhook/main.py
+++ b/dbt-webhook/main.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import json
 from google.cloud import pubsub_v1
-from webhook_utils import verify_dbt_signature, parse_dbt_webhook
+from webhook_utils import verify_dbt_signature, parse_dbt_webhook, map_dbt_to_fabric, create_fabric_job_message
 
 logger = logging.getLogger("primary_logger")
 logger.propagate = False
@@ -12,6 +12,7 @@ gcp_project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", None)
 dbt_webhook_secret = os.environ.get("DBT_WEBHOOK_SECRET", None)
 publisher = pubsub_v1.PublisherClient()
 completed_topic_path = publisher.topic_path(gcp_project_id, "dbt-job-completed")
+fabric_topic_path = publisher.topic_path(gcp_project_id, "fabric-job-events")
 retry_topic_path = publisher.topic_path(gcp_project_id, "dbt-retry-events")
 
 
@@ -93,8 +94,8 @@ def create_retry_message(dbt_info: dict) -> dict:
 def handle_job_success(dbt_info: dict) -> tuple:
     """
     Publish successful completion to the generic dbt-job-completed topic.
-    Includes job_id and run_status as Pub/Sub message attributes for
-    downstream subscription filtering.
+    Also publishes to legacy fabric-job-events topic if there's a Fabric mapping
+    (backward compatibility — will be removed after Fabric migrates to the new topic).
     """
     completion_message = create_completion_message(dbt_info)
 
@@ -114,6 +115,19 @@ def handle_job_success(dbt_info: dict) -> tuple:
             f"Published dbt job completion to Pub/Sub: message_id={message_id}, "
             f"job_id={dbt_info.get('job_id')}, job_name={dbt_info.get('job_name')}"
         )
+
+        # Legacy: also publish to fabric-job-events if this job has a Fabric mapping.
+        # Remove this block after Fabric workflow migrates to dbt-job-completed topic.
+        fabric_config = map_dbt_to_fabric(dbt_info.get("job_id", ""))
+        if fabric_config:
+            fabric_message = create_fabric_job_message(fabric_config, dbt_info)
+            fabric_bytes = json.dumps(fabric_message).encode("utf-8")
+            fabric_future = publisher.publish(fabric_topic_path, fabric_bytes)
+            fabric_msg_id = fabric_future.result()
+            logger.info(
+                f"Published to legacy fabric-job-events: message_id={fabric_msg_id}, "
+                f"workspace_id={fabric_config['workspace_id']}"
+            )
 
         return (
             {

--- a/dbt-webhook/main.py
+++ b/dbt-webhook/main.py
@@ -4,14 +4,15 @@ import logging
 import sys
 import json
 from google.cloud import pubsub_v1
-from webhook_utils import verify_dbt_signature, parse_dbt_webhook, map_dbt_to_fabric
+from webhook_utils import verify_dbt_signature, parse_dbt_webhook
 
 logger = logging.getLogger("primary_logger")
 logger.propagate = False
 gcp_project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", None)
 dbt_webhook_secret = os.environ.get("DBT_WEBHOOK_SECRET", None)
 publisher = pubsub_v1.PublisherClient()
-topic_path = publisher.topic_path(gcp_project_id, "fabric-job-events")
+completed_topic_path = publisher.topic_path(gcp_project_id, "dbt-job-completed")
+retry_topic_path = publisher.topic_path(gcp_project_id, "dbt-retry-events")
 
 
 class CloudLoggingFormatter(logging.Formatter):
@@ -31,12 +32,8 @@ class CloudLoggingFormatter(logging.Formatter):
 
 
 def setup_logging():
-    """
-    Sets up logging for the application.
-    """
     global logger
 
-    # Remove any existing handlers
     if logger.handlers:
         for handler in logger.handlers:
             logger.removeHandler(handler)
@@ -51,68 +48,139 @@ def setup_logging():
 
 
 def handle_unhandled_exception(exc_type, exc_value, exc_traceback):
-    """
-    Handles unhandled exceptions by logging the exception details.
-
-    Args:
-        exc_type (type): The type of the exception that was raised.
-        exc_value (Exception): The exception object that was raised.
-        exc_traceback (traceback): The traceback object that was generated when the exception was raised.
-    """
-    # Check if the exception is of a type that can be skipped (e.g., KeyboardInterrupt)
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
         return
-    # Log the unhandled exception
     logger = logging.getLogger("primary_logger")
     logger.exception(
         "Unhandled exception", exc_info=(exc_type, exc_value, exc_traceback)
     )
 
 
-def create_fabric_job_message(fabric_config: dict, dbt_info: dict) -> dict:
+def create_completion_message(dbt_info: dict) -> dict:
     """
-    Create a generic fabric job request message.
-
-    Args:
-        fabric_config: Fabric job configuration (workspace_id, item_id, job_type)
-        dbt_info: DBT webhook information for context
-
-    Returns:
-        dict: Generic fabric job request message
+    Create a generic dbt job completion message for the dbt-job-completed topic.
+    Downstream workflows filter by job_id via Pub/Sub attribute filters.
     """
     return {
-        "workspace_id": fabric_config["workspace_id"],
-        "item_id": fabric_config["item_id"],
-        "refresh_workspace_id": fabric_config["refresh_workspace_id"],
-        "lakehouse_dataset_id": fabric_config["lakehouse_dataset_id"],
-        "job_type": fabric_config["job_type"],
-        "trigger_source": "dbt_completion",
-        "enable_monitoring": True,
-        "source_job_id": dbt_info.get("job_id", ""),
-        "source_system": "dbt",
-        "execution_context": {
-            "dbt_job_id": dbt_info.get("job_id", ""),
-            "dbt_job_name": dbt_info.get("job_name", ""),
-            "dbt_run_id": dbt_info.get("run_id", ""),
-            "dbt_run_status": dbt_info.get("run_status", ""),
-            "dbt_environment_id": dbt_info.get("environment_id", ""),
-            "dbt_account_id": dbt_info.get("account_id", ""),
-            "event_type": dbt_info.get("event_type", ""),
-        },
-        "execution_data": None,
+        "job_id": dbt_info.get("job_id", ""),
+        "job_name": dbt_info.get("job_name", ""),
+        "run_id": dbt_info.get("run_id", ""),
+        "run_status": dbt_info.get("run_status", ""),
+        "run_status_code": dbt_info.get("run_status_code", ""),
+        "environment_id": dbt_info.get("environment_id", ""),
+        "account_id": dbt_info.get("account_id", ""),
+        "event_type": dbt_info.get("event_type", ""),
     }
+
+
+def create_retry_message(dbt_info: dict) -> dict:
+    """
+    Create a retry event message for a failed dbt job.
+    """
+    return {
+        "job_id": dbt_info.get("job_id", ""),
+        "run_id": dbt_info.get("run_id", ""),
+        "job_name": dbt_info.get("job_name", ""),
+        "run_status": dbt_info.get("run_status", ""),
+        "run_status_code": dbt_info.get("run_status_code", ""),
+        "environment_id": dbt_info.get("environment_id", ""),
+        "account_id": dbt_info.get("account_id", ""),
+        "attempt_number": 0,
+    }
+
+
+def handle_job_success(dbt_info: dict) -> tuple:
+    """
+    Publish successful completion to the generic dbt-job-completed topic.
+    Includes job_id and run_status as Pub/Sub message attributes for
+    downstream subscription filtering.
+    """
+    completion_message = create_completion_message(dbt_info)
+
+    try:
+        message_json = json.dumps(completion_message)
+        message_bytes = message_json.encode("utf-8")
+
+        future = publisher.publish(
+            completed_topic_path,
+            message_bytes,
+            job_id=dbt_info.get("job_id", ""),
+            run_status=dbt_info.get("run_status", ""),
+        )
+        message_id = future.result()
+
+        logger.info(
+            f"Published dbt job completion to Pub/Sub: message_id={message_id}, "
+            f"job_id={dbt_info.get('job_id')}, job_name={dbt_info.get('job_name')}"
+        )
+
+        return (
+            {
+                "status": "success",
+                "message": "Job completion published to dbt-job-completed topic",
+                "message_id": message_id,
+                "dbt_job_id": dbt_info.get("job_id"),
+                "dbt_run_id": dbt_info.get("run_id"),
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.exception(f"Error publishing to Pub/Sub: {str(e)}")
+        return (f"Error publishing to Pub/Sub: {str(e)}", 500)
+
+
+def handle_job_failure(dbt_info: dict) -> tuple:
+    """
+    Publish failed job to the retry topic for automatic retry processing.
+    """
+    logger.info(
+        f"DBT job failed: job_id={dbt_info.get('job_id')}, "
+        f"run_id={dbt_info.get('run_id')}, status={dbt_info.get('run_status')}"
+    )
+
+    try:
+        retry_message = create_retry_message(dbt_info)
+        message_json = json.dumps(retry_message)
+        message_bytes = message_json.encode("utf-8")
+
+        future = publisher.publish(retry_topic_path, message_bytes)
+        message_id = future.result()
+
+        logger.info(
+            f"Published retry event to Pub/Sub: message_id={message_id}, "
+            f"job_id={dbt_info.get('job_id')}, run_id={dbt_info.get('run_id')}"
+        )
+
+        return (
+            {
+                "status": "failure_processed",
+                "message": "Job failure published to retry topic",
+                "message_id": message_id,
+                "dbt_job_id": dbt_info.get("job_id"),
+                "dbt_run_id": dbt_info.get("run_id"),
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.exception(f"Error publishing retry event to Pub/Sub: {str(e)}")
+        return (f"Error publishing retry event: {str(e)}", 500)
 
 
 @functions_framework.http
 def webhook_handler(request):
     """
-    HTTP Cloud Function to handle DBT webhook events and trigger Fabric jobs.
+    Generic dbt Cloud webhook handler.
+    Publishes all successful completions to dbt-job-completed topic with job_id
+    as a message attribute. Downstream workflows (Fabric, Hightouch, etc.)
+    subscribe with attribute filters and act independently.
+    Publishes failures to dbt-retry-events topic for automatic retry.
     """
     setup_logging()
 
     try:
-        # Get request data and signature
         request_body = request.get_data()
         signature = request.headers.get("authorization")
 
@@ -120,12 +188,10 @@ def webhook_handler(request):
             logger.warning("Missing DBT signature header")
             return ("Missing signature", 400)
 
-        # Verify signature
         if not verify_dbt_signature(request_body, signature, dbt_webhook_secret):
             logger.error("Invalid DBT webhook signature")
             return ("Invalid signature", 403)
 
-        # Parse request JSON
         try:
             request_json = json.loads(request_body.decode("utf-8"))
             logger.info(f"DBT webhook payload: {json.dumps(request_json, indent=2)}")
@@ -133,7 +199,6 @@ def webhook_handler(request):
             logger.error(f"Invalid JSON in request body: {str(e)}")
             return ("Invalid JSON", 400)
 
-        # Parse DBT webhook data
         dbt_info = parse_dbt_webhook(request_json)
         logger.info(f"Parsed DBT info: {dbt_info}")
         if not dbt_info:
@@ -141,60 +206,30 @@ def webhook_handler(request):
             return ("Invalid DBT webhook payload", 400)
 
         logger.info(
-            f"Received DBT webhook: event_type={dbt_info.get('event_type')}, job_id={dbt_info.get('job_id')}, run_status={dbt_info.get('run_status')}"
+            f"Received DBT webhook: event_type={dbt_info.get('event_type')}, "
+            f"job_id={dbt_info.get('job_id')}, run_status={dbt_info.get('run_status')}"
         )
 
-        # Only process successful job completions
-        if dbt_info.get("event_type") != "job.run.completed" or (
-            dbt_info.get("run_status") != "Success"
-            and dbt_info.get("run_status_code") != 10
-        ):
+        if dbt_info.get("event_type") != "job.run.completed":
             logger.info(
-                f"Ignoring DBT event - not a successful job completion: {dbt_info.get('event_type')}, status: {dbt_info.get('run_status')}, status_code: {dbt_info.get('run_status_code')}"
+                f"Ignoring DBT event - not a job completion: "
+                f"{dbt_info.get('event_type')}"
             )
-            return ("Event ignored - not a successful job completion", 200)
+            return ("Event ignored - not a job completion", 200)
 
-        # Map DBT job to Fabric configuration
-        fabric_config = map_dbt_to_fabric(dbt_info.get("job_id", ""))
-        if not fabric_config:
-            logger.info(
-                f"No Fabric mapping configured for DBT job ID: {dbt_info.get('job_id')} - webhook processed successfully"
-            )
-            return (
-                "Webhook processed - no Fabric job mapping configured for this DBT job",
-                200,
-            )
+        run_status_code = dbt_info.get("run_status_code")
 
-        # Create fabric job request message
-        fabric_message = create_fabric_job_message(fabric_config, dbt_info)
+        if run_status_code == 20 or dbt_info.get("run_status") == "Error":
+            return handle_job_failure(dbt_info)
 
-        # Publish to Pub/Sub
-        try:
-            message_json = json.dumps(fabric_message)
-            message_bytes = message_json.encode("utf-8")
+        if run_status_code == 10 or dbt_info.get("run_status") == "Success":
+            return handle_job_success(dbt_info)
 
-            future = publisher.publish(topic_path, message_bytes)
-            message_id = future.result()
-
-            logger.info(
-                f"Published Fabric job request to Pub/Sub: message_id={message_id}, workspace_id={fabric_config['workspace_id']}, item_id={fabric_config['item_id']}"
-            )
-
-            return (
-                {
-                    "status": "success",
-                    "message": "Fabric job request published",
-                    "message_id": message_id,
-                    "dbt_job_id": dbt_info.get("job_id"),
-                    "fabric_workspace_id": fabric_config["workspace_id"],
-                    "fabric_item_id": fabric_config["item_id"],
-                },
-                200,
-            )
-
-        except Exception as e:
-            logger.exception(f"Error publishing to Pub/Sub: {str(e)}")
-            return (f"Error publishing to Pub/Sub: {str(e)}", 500)
+        logger.info(
+            f"Ignoring DBT event with unhandled status: "
+            f"{dbt_info.get('run_status')}, status_code: {run_status_code}"
+        )
+        return ("Event ignored - unhandled run status", 200)
 
     except Exception as e:
         logger.exception(f"Unhandled error in webhook handler: {str(e)}")

--- a/dbt-webhook/main.py
+++ b/dbt-webhook/main.py
@@ -144,6 +144,7 @@ def handle_job_success(dbt_info: dict) -> tuple:
     would duplicate the message on dbt-job-completed).
     """
     completion_message = create_completion_message(dbt_info)
+    message_id = None
 
     try:
         message_json = json.dumps(completion_message)
@@ -176,7 +177,11 @@ def handle_job_success(dbt_info: dict) -> tuple:
         try:
             fabric_message = create_fabric_job_message(fabric_config, dbt_info)
             fabric_bytes = json.dumps(fabric_message).encode("utf-8")
-            fabric_future = publisher.publish(fabric_topic_path, fabric_bytes)
+            fabric_future = publisher.publish(
+                fabric_topic_path,
+                fabric_bytes,
+                job_id=dbt_info.get("job_id", ""),
+            )
             fabric_msg_id = fabric_future.result(timeout=10)
             logger.info(
                 f"Published to legacy fabric-job-events: message_id={fabric_msg_id}, "

--- a/dbt-webhook/main.py
+++ b/dbt-webhook/main.py
@@ -218,6 +218,7 @@ def handle_job_failure(dbt_info: dict) -> tuple:
             message_bytes,
             job_id=dbt_info.get("job_id", ""),
             run_status=dbt_info.get("run_status", ""),
+            environment_id=dbt_info.get("environment_id", ""),
         )
         message_id = future.result(timeout=10)
 

--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -257,8 +257,8 @@ def test_cancelled_job_ignored(mock_publisher):
 
 
 @mock.patch.object(main, "publisher")
-def test_non_completion_event_returns_200(mock_publisher):
-    """Non-completion events (e.g., job.run.started) are ignored with 200."""
+def test_non_completion_event_returns_400(mock_publisher):
+    """Non-completion events return 400 because parse_dbt_webhook returns {} for them."""
     payload = {
         "eventType": "job.run.started",
         "accountId": "10206",
@@ -317,3 +317,49 @@ def test_pubsub_error_returns_500(mock_publisher):
 
     assert response[1] == 500
     assert "Pub/Sub" in response[0]
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(main, "publisher")
+def test_valid_hmac_signature_accepted(mock_publisher):
+    """Valid HMAC-SHA256 signature (non-Bearer) is accepted."""
+    import hmac as hmac_lib
+    import hashlib
+
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(status="Success", status_code=10)
+    body = json.dumps(payload).encode("utf-8")
+    secret = "test-secret"
+    valid_signature = hmac_lib.new(
+        secret.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+
+    mock_req = mock.Mock(spec=Request)
+    mock_req.get_data.return_value = body
+    mock_req.headers = {"authorization": valid_signature}
+
+    response = main.webhook_handler(mock_req)
+
+    assert response[1] == 200
+
+
+def test_invalid_hmac_signature_rejected():
+    """Invalid HMAC signature (non-Bearer, wrong value) returns 403."""
+    payload = make_dbt_webhook_payload(status="Success", status_code=10)
+    body = json.dumps(payload).encode("utf-8")
+
+    mock_req = mock.Mock(spec=Request)
+    mock_req.get_data.return_value = body
+    mock_req.headers = {"authorization": "invalid-hmac-value"}
+
+    response = main.webhook_handler(mock_req)
+
+    assert response[1] == 403
+    assert "Invalid signature" in response[0]

--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -56,8 +56,9 @@ def make_dbt_webhook_payload(status="Success", status_code=10, job_id="54170"):
     }
 
 
-def make_mock_request(payload, signature="Bearer test-token"):
-    """Build a mock Flask request with the given payload and auth header."""
+def make_mock_request(payload, signature="Bearer test-secret"):
+    """Build a mock Flask request with the given payload and auth header.
+    Default signature uses the test-secret configured in conftest.py."""
     mock_req = mock.Mock(spec=Request)
     body = json.dumps(payload).encode("utf-8")
     mock_req.get_data.return_value = body
@@ -257,8 +258,8 @@ def test_cancelled_job_ignored(mock_publisher):
 
 
 @mock.patch.object(main, "publisher")
-def test_non_completion_event_returns_400(mock_publisher):
-    """Non-completion events return 400 because parse_dbt_webhook returns {} for them."""
+def test_non_completion_event_returns_200(mock_publisher):
+    """Non-completion events (e.g., job.run.started) are gracefully ignored with 200."""
     payload = {
         "eventType": "job.run.started",
         "accountId": "10206",
@@ -268,11 +269,8 @@ def test_non_completion_event_returns_400(mock_publisher):
 
     response = main.webhook_handler(request)
 
-    # parse_dbt_webhook returns {} for non-completion events,
-    # which is falsy and triggers the "Invalid payload" 400.
-    # This is acceptable because dbt Cloud only sends completion webhooks
-    # when configured correctly.
-    assert response[1] == 400
+    assert response[1] == 200
+    assert "not a job completion" in response[0]
     mock_publisher.publish.assert_not_called()
 
 
@@ -297,7 +295,7 @@ def test_invalid_json_returns_400():
     """Request with invalid JSON returns 400."""
     mock_req = mock.Mock(spec=Request)
     mock_req.get_data.return_value = b"not json"
-    mock_req.headers = {"authorization": "Bearer test-token"}
+    mock_req.headers = {"authorization": "Bearer test-secret"}
 
     response = main.webhook_handler(mock_req)
 
@@ -348,6 +346,17 @@ def test_valid_hmac_signature_accepted(mock_publisher):
     response = main.webhook_handler(mock_req)
 
     assert response[1] == 200
+
+
+def test_invalid_bearer_token_rejected():
+    """Bearer token that doesn't match webhook secret returns 403."""
+    payload = make_dbt_webhook_payload(status="Success", status_code=10)
+    request = make_mock_request(payload, signature="Bearer wrong-secret")
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 403
+    assert "Invalid signature" in response[0]
 
 
 def test_invalid_hmac_signature_rejected():

--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -226,6 +226,28 @@ def test_webhook_invalid_json():
 
 
 @mock.patch.object(main, "publisher")
+def test_webhook_success_with_fabric_mapping_publishes_to_both_topics(mock_publisher):
+    """Successful dbt job with Fabric mapping publishes to both topics."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(
+        status="Success", status_code=10, job_id="163545"
+    )
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    assert mock_publisher.publish.call_count == 2
+
+    call_topics = [call[0][0] for call in mock_publisher.publish.call_args_list]
+    assert main.completed_topic_path in call_topics
+    assert main.fabric_topic_path in call_topics
+
+
+@mock.patch.object(main, "publisher")
 def test_webhook_pubsub_error_returns_500(mock_publisher):
     """Pub/Sub publish failure returns 500."""
     mock_publisher.publish.side_effect = Exception("Pub/Sub unavailable")

--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -1,0 +1,239 @@
+import pytest
+import logging
+import sys
+import json
+from unittest import mock
+from flask import Request
+
+# main is imported by conftest.py with mocked GCP credentials
+import main
+
+
+@pytest.fixture(autouse=True)
+def mock_env_vars(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.setenv("DBT_WEBHOOK_SECRET", "test-secret")
+
+
+@pytest.fixture(autouse=True)
+def setup_logging():
+    logger = logging.getLogger("primary_logger")
+    logger.handlers = []
+    logger.propagate = True
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = main.CloudLoggingFormatter(fmt="%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    yield
+
+    logger.handlers = []
+    logger.propagate = False
+
+
+def make_dbt_webhook_payload(status="Success", status_code=10, job_id="54170"):
+    return {
+        "eventType": "job.run.completed",
+        "accountId": "10206",
+        "data": {
+            "jobId": job_id,
+            "jobName": "Test Job",
+            "runId": "99999",
+            "runStatus": status,
+            "runStatusCode": status_code,
+            "runStatusMessage": f"Run {status}",
+            "environmentId": "12345",
+        },
+    }
+
+
+def make_mock_request(payload, signature="Bearer test-token"):
+    mock_req = mock.Mock(spec=Request)
+    body = json.dumps(payload).encode("utf-8")
+    mock_req.get_data.return_value = body
+    mock_req.headers = {"authorization": signature}
+    return mock_req
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_success_publishes_to_completed_topic(mock_publisher):
+    """Successful dbt job publishes to dbt-job-completed topic."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(status="Success", status_code=10)
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    body = response[0]
+    assert body["status"] == "success"
+    assert body["message"] == "Job completion published to dbt-job-completed topic"
+
+    mock_publisher.publish.assert_called_once()
+    call_args = mock_publisher.publish.call_args
+    assert call_args[0][0] == main.completed_topic_path
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_success_includes_message_attributes(mock_publisher):
+    """Successful completion includes job_id and run_status as Pub/Sub attributes."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(
+        status="Success", status_code=10, job_id="54170"
+    )
+    request = make_mock_request(payload)
+
+    main.webhook_handler(request)
+
+    call_args = mock_publisher.publish.call_args
+    assert call_args[1]["job_id"] == "54170"
+    assert call_args[1]["run_status"] == "Success"
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_success_message_contains_dbt_info(mock_publisher):
+    """Published message contains all dbt completion fields."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(
+        status="Success", status_code=10, job_id="54170"
+    )
+    request = make_mock_request(payload)
+
+    main.webhook_handler(request)
+
+    call_args = mock_publisher.publish.call_args
+    published_bytes = call_args[0][1]
+    message = json.loads(published_bytes.decode("utf-8"))
+    assert message["job_id"] == "54170"
+    assert message["job_name"] == "Test Job"
+    assert message["run_id"] == "99999"
+    assert message["run_status"] == "Success"
+    assert message["run_status_code"] == 10
+    assert message["environment_id"] == "12345"
+    assert message["account_id"] == "10206"
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_success_any_job_id_publishes(mock_publisher):
+    """ALL successful completions publish — no job ID filtering in the webhook."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(
+        status="Success", status_code=10, job_id="999999"
+    )
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    assert response[0]["status"] == "success"
+    mock_publisher.publish.assert_called_once()
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_failure_publishes_to_retry_topic(mock_publisher):
+    """Failed dbt job publishes to retry topic."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-456"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(status="Error", status_code=20)
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    body = response[0]
+    assert body["status"] == "failure_processed"
+    assert body["message"] == "Job failure published to retry topic"
+
+    mock_publisher.publish.assert_called_once()
+    call_args = mock_publisher.publish.call_args
+    assert call_args[0][0] == main.retry_topic_path
+
+    published_bytes = call_args[0][1]
+    retry_msg = json.loads(published_bytes.decode("utf-8"))
+    assert retry_msg["job_id"] == "54170"
+    assert retry_msg["run_id"] == "99999"
+    assert retry_msg["attempt_number"] == 0
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_cancelled_job_ignored(mock_publisher):
+    """Cancelled dbt job is ignored (not success, not error)."""
+    payload = make_dbt_webhook_payload(status="Cancelled", status_code=30)
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    assert "unhandled run status" in response[0]
+    mock_publisher.publish.assert_not_called()
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_non_completion_event_ignored(mock_publisher):
+    """Non-completion events return 400 (parse_dbt_webhook only handles completions)."""
+    payload = {
+        "eventType": "job.run.started",
+        "accountId": "10206",
+        "data": {"jobId": "54170", "runId": "99999"},
+    }
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 400
+    assert "Invalid DBT webhook payload" in response[0]
+    mock_publisher.publish.assert_not_called()
+
+
+def test_webhook_missing_signature():
+    """Request without signature returns 400."""
+    mock_req = mock.Mock(spec=Request)
+    mock_req.get_data.return_value = b"{}"
+    mock_req.headers = {}
+
+    response = main.webhook_handler(mock_req)
+
+    assert response[1] == 400
+    assert "Missing signature" in response[0]
+
+
+def test_webhook_invalid_json():
+    """Request with invalid JSON returns 400."""
+    mock_req = mock.Mock(spec=Request)
+    mock_req.get_data.return_value = b"not json"
+    mock_req.headers = {"authorization": "Bearer test-token"}
+
+    response = main.webhook_handler(mock_req)
+
+    assert response[1] == 400
+    assert "Invalid JSON" in response[0]
+
+
+@mock.patch.object(main, "publisher")
+def test_webhook_pubsub_error_returns_500(mock_publisher):
+    """Pub/Sub publish failure returns 500."""
+    mock_publisher.publish.side_effect = Exception("Pub/Sub unavailable")
+
+    payload = make_dbt_webhook_payload(status="Success", status_code=10)
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 500
+    assert "Pub/Sub" in response[0]

--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -1,3 +1,15 @@
+"""
+Tests for the dbt Cloud webhook handler.
+
+Tests verify:
+  - Successful completions publish to dbt-job-completed topic with correct attributes
+  - Failed completions publish to dbt-retry-events topic
+  - Legacy Fabric dual-publish works for mapped jobs
+  - Fabric publish failures are isolated (non-fatal)
+  - Cancelled/unhandled statuses are ignored
+  - Invalid requests are rejected
+"""
+
 import pytest
 import logging
 import sys
@@ -7,12 +19,6 @@ from flask import Request
 
 # main is imported by conftest.py with mocked GCP credentials
 import main
-
-
-@pytest.fixture(autouse=True)
-def mock_env_vars(monkeypatch):
-    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
-    monkeypatch.setenv("DBT_WEBHOOK_SECRET", "test-secret")
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +40,7 @@ def setup_logging():
 
 
 def make_dbt_webhook_payload(status="Success", status_code=10, job_id="54170"):
+    """Build a realistic dbt Cloud webhook payload for testing."""
     return {
         "eventType": "job.run.completed",
         "accountId": "10206",
@@ -50,6 +57,7 @@ def make_dbt_webhook_payload(status="Success", status_code=10, job_id="54170"):
 
 
 def make_mock_request(payload, signature="Bearer test-token"):
+    """Build a mock Flask request with the given payload and auth header."""
     mock_req = mock.Mock(spec=Request)
     body = json.dumps(payload).encode("utf-8")
     mock_req.get_data.return_value = body
@@ -57,8 +65,13 @@ def make_mock_request(payload, signature="Bearer test-token"):
     return mock_req
 
 
+# ---------------------------------------------------------------------------
+# Success path: generic dbt-job-completed topic
+# ---------------------------------------------------------------------------
+
+
 @mock.patch.object(main, "publisher")
-def test_webhook_success_publishes_to_completed_topic(mock_publisher):
+def test_success_publishes_to_completed_topic(mock_publisher):
     """Successful dbt job publishes to dbt-job-completed topic."""
     mock_future = mock.Mock()
     mock_future.result.return_value = "msg-123"
@@ -70,82 +83,134 @@ def test_webhook_success_publishes_to_completed_topic(mock_publisher):
     response = main.webhook_handler(request)
 
     assert response[1] == 200
-    body = response[0]
-    assert body["status"] == "success"
-    assert body["message"] == "Job completion published to dbt-job-completed topic"
+    assert response[0]["status"] == "success"
+    assert response[0]["message"] == "Job completion published to dbt-job-completed topic"
 
-    mock_publisher.publish.assert_called_once()
+    assert mock_publisher.publish.call_count == 1
     call_args = mock_publisher.publish.call_args
-    assert call_args[0][0] == main.completed_topic_path
+    assert "dbt-job-completed" in call_args[0][0]
+    assert "fabric-job-events" not in call_args[0][0]
 
 
 @mock.patch.object(main, "publisher")
-def test_webhook_success_includes_message_attributes(mock_publisher):
-    """Successful completion includes job_id and run_status as Pub/Sub attributes."""
+def test_success_includes_message_attributes(mock_publisher):
+    """Message attributes include job_id, run_status, and environment_id for filtering."""
     mock_future = mock.Mock()
     mock_future.result.return_value = "msg-123"
     mock_publisher.publish.return_value = mock_future
 
-    payload = make_dbt_webhook_payload(
-        status="Success", status_code=10, job_id="54170"
-    )
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="54170")
     request = make_mock_request(payload)
 
     main.webhook_handler(request)
 
-    call_args = mock_publisher.publish.call_args
-    assert call_args[1]["job_id"] == "54170"
-    assert call_args[1]["run_status"] == "Success"
+    call_kwargs = mock_publisher.publish.call_args[1]
+    assert call_kwargs["job_id"] == "54170"
+    assert call_kwargs["run_status"] == "Success"
+    assert call_kwargs["environment_id"] == "12345"
 
 
 @mock.patch.object(main, "publisher")
-def test_webhook_success_message_contains_dbt_info(mock_publisher):
-    """Published message contains all dbt completion fields."""
+def test_success_message_contains_all_dbt_fields(mock_publisher):
+    """Published message contains all dbt completion fields including humanized status."""
     mock_future = mock.Mock()
     mock_future.result.return_value = "msg-123"
     mock_publisher.publish.return_value = mock_future
 
-    payload = make_dbt_webhook_payload(
-        status="Success", status_code=10, job_id="54170"
-    )
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="54170")
     request = make_mock_request(payload)
 
     main.webhook_handler(request)
 
-    call_args = mock_publisher.publish.call_args
-    published_bytes = call_args[0][1]
+    published_bytes = mock_publisher.publish.call_args[0][1]
     message = json.loads(published_bytes.decode("utf-8"))
     assert message["job_id"] == "54170"
     assert message["job_name"] == "Test Job"
     assert message["run_id"] == "99999"
     assert message["run_status"] == "Success"
     assert message["run_status_code"] == 10
+    assert message["run_status_humanized"] == "Run Success"
     assert message["environment_id"] == "12345"
     assert message["account_id"] == "10206"
+    assert message["event_type"] == "job.run.completed"
 
 
 @mock.patch.object(main, "publisher")
-def test_webhook_success_any_job_id_publishes(mock_publisher):
+def test_success_any_job_id_publishes(mock_publisher):
     """ALL successful completions publish — no job ID filtering in the webhook."""
     mock_future = mock.Mock()
     mock_future.result.return_value = "msg-123"
     mock_publisher.publish.return_value = mock_future
 
-    payload = make_dbt_webhook_payload(
-        status="Success", status_code=10, job_id="999999"
-    )
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="999999")
     request = make_mock_request(payload)
 
     response = main.webhook_handler(request)
 
     assert response[1] == 200
     assert response[0]["status"] == "success"
-    mock_publisher.publish.assert_called_once()
+    assert mock_publisher.publish.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Legacy Fabric dual-publish
+# ---------------------------------------------------------------------------
 
 
 @mock.patch.object(main, "publisher")
-def test_webhook_failure_publishes_to_retry_topic(mock_publisher):
-    """Failed dbt job publishes to retry topic."""
+def test_success_with_fabric_mapping_publishes_to_both_topics(mock_publisher):
+    """Job with Fabric mapping publishes to BOTH completed and fabric topics."""
+    mock_future = mock.Mock()
+    mock_future.result.return_value = "msg-123"
+    mock_publisher.publish.return_value = mock_future
+
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="163545")
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    assert mock_publisher.publish.call_count == 2
+
+    call_topics = [call[0][0] for call in mock_publisher.publish.call_args_list]
+    assert any("dbt-job-completed" in t for t in call_topics)
+    assert any("fabric-job-events" in t for t in call_topics)
+
+
+@mock.patch.object(main, "publisher")
+def test_fabric_publish_failure_is_non_fatal(mock_publisher):
+    """Fabric publish failure does not affect the 200 response or cause retry."""
+    call_count = 0
+
+    def publish_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            mock_future = mock.Mock()
+            mock_future.result.return_value = "msg-123"
+            return mock_future
+        else:
+            raise Exception("Fabric topic unavailable")
+
+    mock_publisher.publish.side_effect = publish_side_effect
+
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="163545")
+    request = make_mock_request(payload)
+
+    response = main.webhook_handler(request)
+
+    assert response[1] == 200
+    assert response[0]["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Failure path: dbt-retry-events topic
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(main, "publisher")
+def test_failure_publishes_to_retry_topic(mock_publisher):
+    """Failed dbt job publishes to retry topic with correct attributes."""
     mock_future = mock.Mock()
     mock_future.result.return_value = "msg-456"
     mock_publisher.publish.return_value = mock_future
@@ -156,13 +221,15 @@ def test_webhook_failure_publishes_to_retry_topic(mock_publisher):
     response = main.webhook_handler(request)
 
     assert response[1] == 200
-    body = response[0]
-    assert body["status"] == "failure_processed"
-    assert body["message"] == "Job failure published to retry topic"
+    assert response[0]["status"] == "failure_processed"
 
-    mock_publisher.publish.assert_called_once()
+    assert mock_publisher.publish.call_count == 1
     call_args = mock_publisher.publish.call_args
-    assert call_args[0][0] == main.retry_topic_path
+    assert "dbt-retry-events" in call_args[0][0]
+    assert "dbt-job-completed" not in call_args[0][0]
+
+    # Verify retry message includes job_id attribute for filtering
+    assert call_args[1]["job_id"] == "54170"
 
     published_bytes = call_args[0][1]
     retry_msg = json.loads(published_bytes.decode("utf-8"))
@@ -171,8 +238,13 @@ def test_webhook_failure_publishes_to_retry_topic(mock_publisher):
     assert retry_msg["attempt_number"] == 0
 
 
+# ---------------------------------------------------------------------------
+# Ignored events
+# ---------------------------------------------------------------------------
+
+
 @mock.patch.object(main, "publisher")
-def test_webhook_cancelled_job_ignored(mock_publisher):
+def test_cancelled_job_ignored(mock_publisher):
     """Cancelled dbt job is ignored (not success, not error)."""
     payload = make_dbt_webhook_payload(status="Cancelled", status_code=30)
     request = make_mock_request(payload)
@@ -185,8 +257,8 @@ def test_webhook_cancelled_job_ignored(mock_publisher):
 
 
 @mock.patch.object(main, "publisher")
-def test_webhook_non_completion_event_ignored(mock_publisher):
-    """Non-completion events return 400 (parse_dbt_webhook only handles completions)."""
+def test_non_completion_event_returns_200(mock_publisher):
+    """Non-completion events (e.g., job.run.started) are ignored with 200."""
     payload = {
         "eventType": "job.run.started",
         "accountId": "10206",
@@ -196,13 +268,21 @@ def test_webhook_non_completion_event_ignored(mock_publisher):
 
     response = main.webhook_handler(request)
 
+    # parse_dbt_webhook returns {} for non-completion events,
+    # which is falsy and triggers the "Invalid payload" 400.
+    # This is acceptable because dbt Cloud only sends completion webhooks
+    # when configured correctly.
     assert response[1] == 400
-    assert "Invalid DBT webhook payload" in response[0]
     mock_publisher.publish.assert_not_called()
 
 
-def test_webhook_missing_signature():
-    """Request without signature returns 400."""
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_signature_returns_400():
+    """Request without Authorization header returns 400."""
     mock_req = mock.Mock(spec=Request)
     mock_req.get_data.return_value = b"{}"
     mock_req.headers = {}
@@ -213,7 +293,7 @@ def test_webhook_missing_signature():
     assert "Missing signature" in response[0]
 
 
-def test_webhook_invalid_json():
+def test_invalid_json_returns_400():
     """Request with invalid JSON returns 400."""
     mock_req = mock.Mock(spec=Request)
     mock_req.get_data.return_value = b"not json"
@@ -226,29 +306,7 @@ def test_webhook_invalid_json():
 
 
 @mock.patch.object(main, "publisher")
-def test_webhook_success_with_fabric_mapping_publishes_to_both_topics(mock_publisher):
-    """Successful dbt job with Fabric mapping publishes to both topics."""
-    mock_future = mock.Mock()
-    mock_future.result.return_value = "msg-123"
-    mock_publisher.publish.return_value = mock_future
-
-    payload = make_dbt_webhook_payload(
-        status="Success", status_code=10, job_id="163545"
-    )
-    request = make_mock_request(payload)
-
-    response = main.webhook_handler(request)
-
-    assert response[1] == 200
-    assert mock_publisher.publish.call_count == 2
-
-    call_topics = [call[0][0] for call in mock_publisher.publish.call_args_list]
-    assert main.completed_topic_path in call_topics
-    assert main.fabric_topic_path in call_topics
-
-
-@mock.patch.object(main, "publisher")
-def test_webhook_pubsub_error_returns_500(mock_publisher):
+def test_pubsub_error_returns_500(mock_publisher):
     """Pub/Sub publish failure returns 500."""
     mock_publisher.publish.side_effect = Exception("Pub/Sub unavailable")
 

--- a/dbt-webhook/requirements-test.txt
+++ b/dbt-webhook/requirements-test.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+pytest==8.2.0
+pytest-mock==3.14.0

--- a/dbt-webhook/webhook_utils.py
+++ b/dbt-webhook/webhook_utils.py
@@ -1,7 +1,6 @@
 import hmac
 import hashlib
 import logging
-import os
 
 logger = logging.getLogger("primary_logger")
 
@@ -9,28 +8,17 @@ logger = logging.getLogger("primary_logger")
 def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bool:
     """
     Verify DBT Cloud webhook authentication.
-    DBT Cloud sends JWT Bearer tokens in Authorization header instead of HMAC signatures.
-
-    Args:
-        request_body: Raw request body as bytes
-        signature: Authorization header value from DBT Cloud
-        secret: DBT webhook secret from environment (currently unused for JWT)
-
-    Returns:
-        bool: True if signature is valid, False otherwise
+    DBT Cloud sends JWT Bearer tokens in Authorization header.
     """
     if not signature:
         logger.warning("Missing authorization header for DBT webhook verification")
         return False
 
     try:
-        # DBT Cloud sends JWT Bearer tokens, not HMAC signatures
-        # For now, accept any Bearer token (DBT handles authentication)
         if signature.startswith("Bearer "):
             logger.info("Valid JWT Bearer token received from DBT Cloud")
             return True
 
-        # Fallback: Try HMAC validation for compatibility
         computed_hmac = hmac.new(
             secret.encode("utf-8"), request_body, hashlib.sha256
         ).hexdigest()
@@ -48,21 +36,12 @@ def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bo
 def parse_dbt_webhook(payload: dict) -> dict:
     """
     Parse DBT Cloud webhook payload and extract relevant information.
-
-    Args:
-        payload: DBT webhook JSON payload
-
-    Returns:
-        dict: Extracted information for fabric job mapping
     """
     try:
-        # Extract common DBT webhook fields
         event_type = payload.get("eventType", "")
         data = payload.get("data", {})
 
-        # Handle job completion events
         if event_type == "job.run.completed":
-            # DBT webhook puts all fields directly in 'data', not nested under 'job'/'run'
             return {
                 "event_type": event_type,
                 "job_id": str(data.get("jobId", "")),
@@ -80,43 +59,3 @@ def parse_dbt_webhook(payload: dict) -> dict:
         return {}
 
     return {}
-
-
-def map_dbt_to_fabric(dbt_job_id: str) -> dict:
-    """
-    Map DBT job ID to Fabric workspace and item configuration.
-
-    Args:
-        dbt_job_id: DBT job ID from webhook
-
-    Returns:
-        dict: Fabric job configuration or None if no mapping found
-    """
-    # TODO: Replace with dynamic configuration from database or config file
-    dbt_to_fabric_mapping = {
-        # "US Donations" to Fabric CopyJob
-        "163545": {
-            "workspace_id": "c2bafcfd-df3d-4383-8f76-aed296260453",
-            "item_id": "457998b0-be0c-437c-9b1a-4e5f17b3bf77",
-            "refresh_workspace_id": "b3d68b22-ae01-4017-af31-1392c5c54a6c",
-            "lakehouse_dataset_id": "1402b359-a8e4-48f2-a69e-50bff4e37122",
-            "job_type": "Execute",
-        }
-        # Testing "On Demand - Utilities" to "Lakehouse Test 2"
-        # "23366": {
-        #     "workspace_id": "c264b9e2-3d6e-483e-9898-1daf345ffcef",
-        #     "item_id": "752c9a6a-7196-4a56-90f2-775fa3d1a965",
-        #     "job_type": "Execute",
-        # }
-        # Add more mappings as needed
-    }
-
-    mapping = dbt_to_fabric_mapping.get(dbt_job_id)
-    if not mapping:
-        logger.warning(f"No Fabric job mapping found for DBT job ID: {dbt_job_id}")
-        return {}
-
-    logger.info(
-        f"Found Fabric mapping for DBT job {dbt_job_id}: workspace={mapping['workspace_id']}, item={mapping['item_id']}"
-    )
-    return mapping

--- a/dbt-webhook/webhook_utils.py
+++ b/dbt-webhook/webhook_utils.py
@@ -18,15 +18,11 @@ def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bo
     """
     Verify dbt Cloud webhook authentication.
 
-    dbt Cloud sends JWT Bearer tokens in the Authorization header. This function
-    accepts any Bearer token without validating the JWT signature — dbt Cloud is
-    trusted at the network layer (Cloud Function is not publicly discoverable).
+    dbt Cloud sends a Bearer token in the Authorization header. We validate it
+    against the configured webhook secret using constant-time comparison.
 
     For non-Bearer signatures, falls back to HMAC-SHA256 validation for
     compatibility with older webhook configurations.
-
-    Known limitation: The Bearer path does not verify token content. If stricter
-    auth is needed, add PyJWT validation or compare against the webhook secret.
     """
     if not signature:
         logger.warning("Missing authorization header for DBT webhook verification")
@@ -34,14 +30,21 @@ def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bo
 
     try:
         if signature.startswith("Bearer "):
-            logger.info("Valid JWT Bearer token received from DBT Cloud")
-            return True
+            token = signature[len("Bearer "):]
+            if not secret:
+                logger.warning("No webhook secret configured — cannot validate Bearer token")
+                return False
+            if hmac.compare_digest(token, secret):
+                logger.info("Bearer token validated successfully")
+                return True
+            logger.warning("Bearer token does not match webhook secret")
+            return False
 
         computed_hmac = hmac.new(
             secret.encode("utf-8"), request_body, hashlib.sha256
         ).hexdigest()
 
-        signature_valid = computed_hmac == signature
+        signature_valid = hmac.compare_digest(computed_hmac, signature)
         logger.debug(f"HMAC signature validation result: {signature_valid}")
 
         return signature_valid
@@ -55,15 +58,18 @@ def parse_dbt_webhook(payload: dict) -> dict:
     """
     Parse dbt Cloud webhook payload and extract relevant fields.
 
-    Only processes job.run.completed events. Returns an empty dict for all
-    other event types (the caller checks event_type to decide how to handle).
+    Returns a dict with at minimum 'event_type' for ALL event types, so the
+    caller can distinguish between a bad payload (empty dict) and a valid
+    non-completion event (dict with event_type but no other fields).
 
     Returns:
-        dict: Parsed fields if event type is job.run.completed, empty dict otherwise.
-        Never returns None.
+        dict: Parsed fields. Empty dict only on parse failure.
     """
     try:
         event_type = payload.get("eventType", "")
+        if not event_type:
+            return {}
+
         data = payload.get("data", {})
 
         if event_type == "job.run.completed":
@@ -73,13 +79,14 @@ def parse_dbt_webhook(payload: dict) -> dict:
                 "job_name": data.get("jobName", ""),
                 "run_id": str(data.get("runId", "")),
                 "run_status": data.get("runStatus", ""),
-                "run_status_code": data.get("runStatusCode", ""),
+                "run_status_code": int(data.get("runStatusCode", 0)),
                 "run_status_humanized": data.get("runStatusMessage", ""),
                 "environment_id": str(data.get("environmentId", "")),
                 "account_id": str(payload.get("accountId", "")),
             }
 
-        return {}
+        # Non-completion event — return event_type so caller can return 200
+        return {"event_type": event_type}
 
     except Exception as e:
         logger.exception(f"Error parsing DBT webhook payload: {str(e)}")

--- a/dbt-webhook/webhook_utils.py
+++ b/dbt-webhook/webhook_utils.py
@@ -1,3 +1,12 @@
+"""
+Utility functions for the dbt Cloud webhook handler.
+
+Contains:
+  - Webhook signature verification
+  - Payload parsing
+  - Legacy Fabric job mapping (temporary, for parallel transition)
+"""
+
 import hmac
 import hashlib
 import logging
@@ -7,8 +16,17 @@ logger = logging.getLogger("primary_logger")
 
 def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bool:
     """
-    Verify DBT Cloud webhook authentication.
-    DBT Cloud sends JWT Bearer tokens in Authorization header.
+    Verify dbt Cloud webhook authentication.
+
+    dbt Cloud sends JWT Bearer tokens in the Authorization header. This function
+    accepts any Bearer token without validating the JWT signature — dbt Cloud is
+    trusted at the network layer (Cloud Function is not publicly discoverable).
+
+    For non-Bearer signatures, falls back to HMAC-SHA256 validation for
+    compatibility with older webhook configurations.
+
+    Known limitation: The Bearer path does not verify token content. If stricter
+    auth is needed, add PyJWT validation or compare against the webhook secret.
     """
     if not signature:
         logger.warning("Missing authorization header for DBT webhook verification")
@@ -35,7 +53,14 @@ def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bo
 
 def parse_dbt_webhook(payload: dict) -> dict:
     """
-    Parse DBT Cloud webhook payload and extract relevant information.
+    Parse dbt Cloud webhook payload and extract relevant fields.
+
+    Only processes job.run.completed events. Returns an empty dict for all
+    other event types (the caller checks event_type to decide how to handle).
+
+    Returns:
+        dict: Parsed fields if event type is job.run.completed, empty dict otherwise.
+        Never returns None.
     """
     try:
         event_type = payload.get("eventType", "")
@@ -54,14 +79,26 @@ def parse_dbt_webhook(payload: dict) -> dict:
                 "account_id": str(payload.get("accountId", "")),
             }
 
+        return {}
+
     except Exception as e:
         logger.exception(f"Error parsing DBT webhook payload: {str(e)}")
         return {}
 
 
-# Legacy Fabric mapping — kept for backward compatibility during parallel transition.
-# Remove after Fabric workflow migrates to dbt-job-completed topic.
+# ---------------------------------------------------------------------------
+# Legacy Fabric mapping — kept for backward compatibility during parallel
+# transition. Remove after Fabric workflow migrates to dbt-job-completed topic.
+# ---------------------------------------------------------------------------
+
 def map_dbt_to_fabric(dbt_job_id: str) -> dict:
+    """
+    Map a dbt job ID to Fabric workspace and item configuration.
+
+    Returns the Fabric config dict if the job has a mapping, empty dict otherwise.
+    This mapping will be removed when the Fabric workflow subscribes to the
+    dbt-job-completed topic with a Pub/Sub attribute filter instead.
+    """
     dbt_to_fabric_mapping = {
         "163545": {
             "workspace_id": "c2bafcfd-df3d-4383-8f76-aed296260453",
@@ -84,6 +121,11 @@ def map_dbt_to_fabric(dbt_job_id: str) -> dict:
 
 
 def create_fabric_job_message(fabric_config: dict, dbt_info: dict) -> dict:
+    """
+    Build the message payload for the legacy fabric-job-events topic.
+
+    This message format is consumed by the fabric-job-workflow in Cloud Workflows.
+    """
     return {
         "workspace_id": fabric_config["workspace_id"],
         "item_id": fabric_config["item_id"],
@@ -105,5 +147,3 @@ def create_fabric_job_message(fabric_config: dict, dbt_info: dict) -> dict:
         },
         "execution_data": None,
     }
-
-    return {}

--- a/dbt-webhook/webhook_utils.py
+++ b/dbt-webhook/webhook_utils.py
@@ -58,4 +58,52 @@ def parse_dbt_webhook(payload: dict) -> dict:
         logger.exception(f"Error parsing DBT webhook payload: {str(e)}")
         return {}
 
+
+# Legacy Fabric mapping — kept for backward compatibility during parallel transition.
+# Remove after Fabric workflow migrates to dbt-job-completed topic.
+def map_dbt_to_fabric(dbt_job_id: str) -> dict:
+    dbt_to_fabric_mapping = {
+        "163545": {
+            "workspace_id": "c2bafcfd-df3d-4383-8f76-aed296260453",
+            "item_id": "457998b0-be0c-437c-9b1a-4e5f17b3bf77",
+            "refresh_workspace_id": "b3d68b22-ae01-4017-af31-1392c5c54a6c",
+            "lakehouse_dataset_id": "1402b359-a8e4-48f2-a69e-50bff4e37122",
+            "job_type": "Execute",
+        }
+    }
+
+    mapping = dbt_to_fabric_mapping.get(dbt_job_id)
+    if not mapping:
+        return {}
+
+    logger.info(
+        f"Found Fabric mapping for DBT job {dbt_job_id}: "
+        f"workspace={mapping['workspace_id']}, item={mapping['item_id']}"
+    )
+    return mapping
+
+
+def create_fabric_job_message(fabric_config: dict, dbt_info: dict) -> dict:
+    return {
+        "workspace_id": fabric_config["workspace_id"],
+        "item_id": fabric_config["item_id"],
+        "refresh_workspace_id": fabric_config["refresh_workspace_id"],
+        "lakehouse_dataset_id": fabric_config["lakehouse_dataset_id"],
+        "job_type": fabric_config["job_type"],
+        "trigger_source": "dbt_completion",
+        "enable_monitoring": True,
+        "source_job_id": dbt_info.get("job_id", ""),
+        "source_system": "dbt",
+        "execution_context": {
+            "dbt_job_id": dbt_info.get("job_id", ""),
+            "dbt_job_name": dbt_info.get("job_name", ""),
+            "dbt_run_id": dbt_info.get("run_id", ""),
+            "dbt_run_status": dbt_info.get("run_status", ""),
+            "dbt_environment_id": dbt_info.get("environment_id", ""),
+            "dbt_account_id": dbt_info.get("account_id", ""),
+            "event_type": dbt_info.get("event_type", ""),
+        },
+        "execution_data": None,
+    }
+
     return {}


### PR DESCRIPTION
## Why
Adding downstream integrations currently requires modifying Python code in the webhook handler. This PR makes the handler a generic event publisher so new integrations are Terraform-only changes.

## Type of Change
- [x] Refactoring
- [x] New feature

## dbt-webhook changes
- Successful completions publish to a generic dbt-job-completed Pub/Sub topic with job_id, run_status, and environment_id as message attributes for downstream subscription filtering
- Failed completions publish to dbt-retry-events topic for automatic retry
- Legacy Fabric publishing preserved during parallel transition — Fabric publish failures are isolated (logged, non-fatal) so they cannot trigger webhook retries or duplicate messages
- 14 unit tests with distinct topic path mocks for routing verification

## CI/CD improvements
- run-tests.yml: Detects changed function directories dynamically, runs pytest for each
- auto-merge-dependabot.yml: Auto-merges patch and minor Dependabot bumps

## Companion changes (separate repos)
- cru-terraform: New Pub/Sub topic, Eventarc triggers, Hightouch workflow (upcoming)
- dse-dbt-jobs-as-code: NetSuite for MPDX extract jobs (PR #13, merged)
- dse-dbt: netsuite_for_mpdx config (PR #1445)

## Code review
Two rounds of 5-persona review (Architect, Sr Data Engineer, DevOps, 2x Data Engineer). Round 1: 12 findings, all fixed. Round 2: 3 findings, all fixed.

## Test plan
- [x] 14 unit tests pass locally
- [ ] Deploy and verify Fabric workflow still receives events
- [ ] Verify new dbt-job-completed topic receives all completions

## Jira
- DT-495

Generated with Claude Code