### PR TITLE
Revert Bearer token validation — fix dbt webhook auth broken since April 9

### DIFF
--- a/dbt-webhook/main.py
+++ b/dbt-webhook/main.py
@@ -27,8 +27,6 @@ Related:
 """
 
 import functions_framework
-import hashlib
-import hmac
 import os
 import logging
 import sys
@@ -275,14 +273,6 @@ def webhook_handler(request):
         if not signature:
             logger.warning("Missing DBT signature header")
             return ("Missing signature", 400)
-
-        # Debug logging for signature validation (remove after confirming auth works)
-        logger.info(f"Auth header (first 10 chars): {signature[:10] if signature else 'None'}...")
-        logger.info(f"Auth header starts with Bearer: {signature.startswith('Bearer ') if signature else False}")
-        logger.info(f"Secret loaded (length): {len(dbt_webhook_secret) if dbt_webhook_secret else 0}")
-        logger.info(f"Request body length: {len(request_body)}")
-        computed = hmac.new(dbt_webhook_secret.encode("utf-8"), request_body, hashlib.sha256).hexdigest() if dbt_webhook_secret else "no-secret"
-        logger.info(f"Computed HMAC (first 10 chars): {computed[:10]}...")
 
         if not verify_dbt_signature(request_body, signature, dbt_webhook_secret):
             logger.error("Invalid DBT webhook signature")

--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -348,15 +348,15 @@ def test_valid_hmac_signature_accepted(mock_publisher):
     assert response[1] == 200
 
 
-def test_invalid_bearer_token_rejected():
-    """Bearer token that doesn't match webhook secret returns 403."""
+def test_any_bearer_token_accepted():
+    """Any Bearer token is accepted — the API Gateway rewrites the original
+    dbt Cloud token into its own JWT, so we cannot validate the value."""
     payload = make_dbt_webhook_payload(status="Success", status_code=10)
-    request = make_mock_request(payload, signature="Bearer wrong-secret")
+    request = make_mock_request(payload, signature="Bearer any-token-value")
 
     response = main.webhook_handler(request)
 
-    assert response[1] == 403
-    assert "Invalid signature" in response[0]
+    assert response[1] == 200
 
 
 def test_invalid_hmac_signature_rejected():

--- a/dbt-webhook/webhook_utils.py
+++ b/dbt-webhook/webhook_utils.py
@@ -18,11 +18,18 @@ def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bo
     """
     Verify dbt Cloud webhook authentication.
 
-    dbt Cloud sends a Bearer token in the Authorization header. We validate it
-    against the configured webhook secret using constant-time comparison.
+    Two paths:
+      - Bearer tokens: Accepted without validation (see WARNING below)
+      - HMAC signatures: Validated against the webhook secret
 
-    For non-Bearer signatures, falls back to HMAC-SHA256 validation for
-    compatibility with older webhook configurations.
+    WARNING — DO NOT add Bearer token validation here. The API Gateway
+    rewrites the original dbt Cloud Authorization header with its own JWT
+    before forwarding to this function. The token value this function
+    receives is NOT the dbt Cloud signing key — it is an unrelated gateway
+    JWT. Attempting to validate it against the webhook secret will always
+    fail and will break ALL downstream pipelines (Fabric, Hightouch, MPDX).
+    See docs/ARCHITECTURE.md "Webhook Authentication" for the full
+    explanation of why this works this way.
     """
     if not signature:
         logger.warning("Missing authorization header for DBT webhook verification")
@@ -30,14 +37,13 @@ def verify_dbt_signature(request_body: bytes, signature: str, secret: str) -> bo
 
     try:
         if signature.startswith("Bearer "):
-            token = signature[len("Bearer "):]
-            if not secret:
-                logger.warning("No webhook secret configured — cannot validate Bearer token")
-                return False
-            if hmac.compare_digest(token, secret):
-                logger.info("Bearer token validated successfully")
-                return True
-            logger.warning("Bearer token does not match webhook secret")
+            # Gateway JWT — not the original dbt Cloud key. Do not validate.
+            # See docstring WARNING and docs/ARCHITECTURE.md for details.
+            logger.info("Bearer token received via API Gateway — accepted")
+            return True
+
+        if not secret:
+            logger.warning("No webhook secret configured — cannot validate HMAC signature")
             return False
 
         computed_hmac = hmac.new(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,6 +223,45 @@ When testing workflow YAML directly via `gcloud workflows deploy` (not through T
 | `hightouch-completed` | hightouch-workflow | mpdx-webhook-workflow | Trigger MPDX webhook after Hightouch sync completes |
 | `dbt-retry-events` | dbt-webhook (on failure) | dbt-retry-workflow | Retry transient dbt Cloud job failures |
 
+## Webhook Authentication
+
+### How dbt Cloud Webhook Auth Works (and Why We Don't Validate the Bearer Token)
+
+dbt Cloud webhooks use HMAC-SHA256 for authentication. When dbt Cloud sends a webhook, it computes `HMAC-SHA256(signing_key, request_body)` and sends the hex digest in the `Authorization` header (no `Bearer` prefix). The [dbt Cloud docs](https://docs.getdbt.com/docs/deploy/webhooks#validate-a-webhook) show this validation pattern:
+
+```python
+auth_header = request.headers.get('authorization', None)
+app_secret = os.environ['MY_DBT_CLOUD_AUTH_TOKEN'].encode('utf-8')
+signature = hmac.new(app_secret, request_body, hashlib.sha256).hexdigest()
+return signature == auth_header
+```
+
+However, our Cloud Function sits behind a Google API Gateway (ESPv2). The gateway intercepts the `Authorization` header, replaces the original HMAC value with its own JWT (prefixed with `Bearer`), and forwards the rewritten request to the Cloud Function. The function never sees the original HMAC signature.
+
+**The result:**
+- The `Authorization` header the function receives starts with `Bearer eyJ...` (a gateway JWT)
+- This is NOT the dbt Cloud signing key and NOT the HMAC signature
+- The original HMAC value is gone — the gateway consumed it
+
+**What this means for the code (`webhook_utils.py`):**
+- Bearer tokens are accepted without validation because the value is the gateway JWT, not a dbt Cloud credential
+- The HMAC validation path exists for direct calls that bypass the gateway (e.g., manual `curl` testing without the `Bearer` prefix)
+- **DO NOT** add Bearer token validation — it will always fail and will break all downstream pipelines
+
+**The signing key still matters:**
+- The signing key configured in dbt Cloud must match `dbt-webhook_DBT_WEBHOOK_SECRET` in Secret Manager
+- dbt Cloud uses this key to compute the HMAC it sends — if they don't match, dbt Cloud's own endpoint test fails
+- The key is stored in [1Password](https://start.1password.com/open/i?a=JYIIWWYNKNGGFKU535Y2OR2DOE&v=dhvopdqasf4myknupv5egnktui&i=iwbonr5ku3c5x5ktn2bxuiuu2m&h=cru-data-team.1password.com)
+
+**What protects us:**
+- The API Gateway URL is not publicly discoverable
+- The gateway requires proper routing from dbt Cloud's webhook infrastructure
+- The HMAC path validates direct calls
+
+### Fivetran Webhook Auth (Different Pattern)
+
+Fivetran uses `X-Fivetran-Signature-256` instead of `Authorization`, so the API Gateway does not intercept it. The `fivetran-webhook` function validates the HMAC directly. This is not affected by the gateway rewrite issue.
+
 ## Secrets
 
 All secrets are stored in GCP Secret Manager in project `cru-data-orchestration-prod`. Terraform creates the secret resources; values are added manually via the GCP Console or `gcloud secrets versions add`.


### PR DESCRIPTION
## Why

The dbt-webhook Cloud Function has been rejecting all dbt Cloud webhooks since April 9 (dot PR #94), breaking the Fabric pipeline (US Donations) and blocking the new Hightouch/MPDX orchestration chain (DT-495).

## Type of Change
- [x] Bug fix

## Root Cause

PR #94 added Bearer token validation — comparing the token against the webhook secret. However, the API Gateway (ESPv2) rewrites the Authorization header with its own JWT before forwarding to the Cloud Function. The function never sees the original dbt Cloud signing key, so validation always fails.

## Fix

- Revert the Bearer path to accept any Bearer token (pre-PR #94 behavior)
- Add a guard for missing webhook secret on the HMAC path
- Add WARNING in webhook_utils.py docstring to prevent re-introducing Bearer validation
- Add "Webhook Authentication" section to ARCHITECTURE.md explaining the full auth flow
- Remove temporary debug logging
- Update tests to match reverted behavior

## Test Plan
- [ ] CI tests pass
- [ ] Merge and auto-deploy to prod
- [ ] dbt Cloud endpoint test succeeds (Settings → Webhooks → Test)
- [ ] Trigger beta-prod netsuite_for_mpdx job (1032904) — verify Hightouch workflow executes
- [ ] Verify Fabric workflow executes on next US Donations completion

Co-authored-by: Phyllis Helton <phyllis.helton@cru.org>
Co-authored-by: Claude <noreply@anthropic.com>