### PR TITLE
Design: Fivetran replication-slot safety-valve sync mechanism (DT-561)

### DIFF
--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -1,185 +1,138 @@
-# Design: Fivetran / RDS Replication-Slot Safety Valve
+# Design: Fivetran Replication-Slot Safety-Valve Sync (DSE mechanism)
 
 **Status:** Draft — 2026-06-17
-**Origin:** Action item from the 2026-06-16 replication-slot review (Data Engineering + DevOps Engineering).
-**Reference:** Datadog notebook 14785624 — "Fivetran Slot Safety Valve: Metrics, Limits & Trigger Thresholds" (owner `team:devops-engineering-team`). Companion pipeline view: notebook 14785154.
-**Related:** [DT-511](https://jira.cru.org/browse/DT-511) (the `fivetran_dbt` Workflow fires the downstream dbt build on `sync_end` regardless of sync success).
+**Origin:** Agreed approach from the 2026-06-16 replication-slot review (Data Engineering + DevOps Engineering). This plan is the result of that discussion.
+**Reference:** Datadog notebook 14785624 — "Fivetran Slot Safety Valve: Metrics, Limits & Trigger Thresholds" (owner `team:devops-engineering-team`) holds the metric, the per-instance caps, and the 50% / 70% / 100% thresholds. Companion pipeline view: notebook 14785154.
 
 ---
 
-## 1. Problem
+## 1. Scope and ownership boundary
 
 Three production AWS RDS Postgres instances feed the warehouse through Fivetran via logical
 replication. Each Fivetran `pgoutput` replication slot retains write-ahead log (WAL) on the
-RDS primary until Fivetran consumes it — a sync advances the slot's `restart_lsn` and
-releases the retained WAL. Between syncs, or when a connector is paused or broken, retained
-WAL accumulates.
+RDS primary until Fivetran consumes it; a sync advances the slot's `restart_lsn` and releases
+the retained WAL. If retained WAL reaches the instance's `max_slot_wal_keep_size` cap,
+Postgres invalidates the slot and Fivetran must perform a full re-snapshot — the mechanism
+behind the recurring "Invalid Replication Slot" connector breaks. The cap protects database
+storage (no outage), but invalidation plus full re-sync is disruptive, and it is silent until
+it happens.
 
-Each instance has a hard cap (`max_slot_wal_keep_size`, set in cru-terraform). When retained
-WAL reaches the cap, Postgres invalidates the slot and Fivetran must perform a full
-re-snapshot. That invalidation is the mechanism behind the recurring "Invalid Replication
-Slot" connector breaks. The cap protects database storage (no outage), but invalidation plus
-full re-sync is disruptive and costly, and it is silent until it happens.
+The agreed remedy is a safety valve: when retained WAL reaches **50% of an instance's cap**,
+automatically force a Fivetran sync to drain the slot before it can approach invalidation.
 
-**Goal:** automatically drain a slot — by forcing a Fivetran sync — when retained WAL
-approaches the cap, before invalidation occurs; and escalate to a human when a forced sync
-cannot drain it (the paused/broken-connector case). A reliable valve also makes it safe to
-relax sync schedules without risking slot invalidation.
+**This document covers only the Data Engineering piece: the mechanism that runs the Fivetran
+sync when a slot reaches 50%.** Everything else is owned by DevOps Engineering and handled
+through their standard process:
 
-## 2. Metric, targets, and limits
+| Owned by **DevOps Engineering** (not specified here) | Owned by **Data Engineering** (this doc) |
+|---|---|
+| The RDS instances and the `max_slot_wal_keep_size` caps | The mechanism that, on the 50% trigger, runs a Fivetran sync to drain the slot |
+| The Datadog metric, the 50% / 70% / 100% thresholds, and the monitors | Connector-state handling around that sync (resume / no-op / stop) |
+| Detection at 50% and the call to the DSE mechanism | Not mutating connector scheduling as a side effect |
+| Human escalation (70%) and all alerting | Emitting a structured failure signal for DevOps's alerting to consume |
 
-### Metric
+DevOps's monitor detects the 50% threshold and invokes the DSE mechanism. The mechanism's job
+is to drain the slot via Fivetran; it does not own detection, thresholds, or escalation.
 
-| Metric | Use |
-|--------|-----|
-| `aws.rds.oldest_replication_slot_lag` | **Primary** — bytes of WAL retained by the most-lagging slot (the Fivetran `pgoutput` slot). Filter by `dbinstanceidentifier`; compare against the cap. |
-| `aws.rds.transaction_logs_generation` | WAL fill-rate (bytes/sec) — estimate time-to-cap. |
-| `aws.rds.transaction_logs_disk_usage` | Secondary — total WAL on disk (slot + checkpoint). |
+## 2. Targets
 
-`aws.rds.oldest_logical_replication_slot_lag` (returns −1 / unreliable on these instances)
-and `aws.rds.replication_slot_disk_usage` (slot state files, ~8 KB — not WAL retained) must
-not be used.
+| RDS instance (`dbinstanceidentifier`) | Fivetran connector | Source (cru-terraform) |
+|------|------|------|
+| `mpdx-api-prod` | `loft_unabashed` | `applications/mpdx/api/prod/locals.tf` |
+| `global-registry-flat-prod` | `freebee_tuberculosis` | `applications/global-registry/prod/locals.tf` |
+| `global-registry-prod` | **to confirm** (see Section 7) | `applications/global-registry/prod/locals.tf` |
 
-The metric is in **bytes**, not a percentage; the percentage of cap is computed per
-instance. The Datadog value is CloudWatch-polled and is therefore ~5–15 minutes stale, which
-is acceptable at a 50%-of-cap trigger that has hours of runway.
+The instance-to-connector map must be a hard-coded, reviewed table in the mechanism's config
+(mirroring `connector_to_dbt_mapping`), not inferred at runtime. The metric, caps, and
+thresholds live in notebook 14785624 and are DevOps-owned — not reproduced here.
 
-### Targets and caps (`max_slot_wal_keep_size`, verified in cru-terraform)
+## 3. Architecture
 
-| Instance (`dbinstanceidentifier`) | Cap | Cap (MB / bytes) | cru-terraform source |
-|------|-----|------|------|
-| `mpdx-api-prod` | 100 GiB | 102400 / 107,374,182,400 | `applications/mpdx/api/prod/locals.tf` |
-| `global-registry-prod` | 75 GiB | 76800 / 80,530,636,800 | `applications/global-registry/prod/locals.tf` |
-| `global-registry-flat-prod` | 75 GiB | 76800 / 80,530,636,800 | `applications/global-registry/prod/locals.tf` |
-
-The Fivetran connector that maps to each instance must be confirmed against the Fivetran
-account and DOT configuration before implementation (see Section 8).
-
-## 3. Thresholds (percentage of each instance's cap)
-
-| Tier | % of cap | MPDX | Global Registry (both) | Action |
-|------|----------|------|------------------------|--------|
-| Auto-trigger (valve) | 50% | 50 GiB | 37.5 GiB | force a Fivetran sync to drain the slot |
-| Human escalation | ~70% | 70 GiB | 50 GiB | notify `@devops-engineering-team@cru.org` |
-| Hard cap (invalidation) | 100% | 100 GiB | 75 GiB | slot dropped → full re-sync (the backstop) |
-
-The valve at 50% self-heals before the 70% human monitor fires. RDS storage autoscaling and
-the cap remain the ultimate backstop below all of this.
-
-## 4. Architecture (decision: 2026-06-17)
-
-**Decision:** a hybrid that fits DOT's existing push-not-poll architecture (see
-`ARCHITECTURE.md`) and adds no new direct database access:
-
-- **Escalation (70%):** a Datadog monitor on `aws.rds.oldest_replication_slot_lag` per
-  instance, notifying `@devops-engineering-team@cru.org`. Pure monitoring, DevOps-owned;
-  partially defined already in the reference notebook.
-- **Valve (50%):** a Datadog monitor at 50% of cap → webhook → thin Cloud Function
-  (validate + publish to Pub/Sub) → Cloud Workflow (orchestration: status check → resume →
-  force-sync → escalate-on-failure, with cooldown). This is exactly the standard DOT flow.
+The mechanism follows DOT's standard push pattern (`ARCHITECTURE.md`): a thin Cloud Function
+validates the inbound trigger and publishes to Pub/Sub; a Cloud Workflow performs the
+orchestration. It reuses the existing `fivetran-trigger/fivetran_client.py` primitives.
 
 ```
-RDS → CloudWatch → Datadog  (aws.rds.oldest_replication_slot_lag, by dbinstanceidentifier)
-  │  datadog_monitor: lag > 50% of cap (per instance)
-  ▼  webhook
-Cloud Function  (validate webhook, classify instance→connector, publish to Pub/Sub, return 200)
+DevOps Datadog monitor (slot at 50% of cap)  →  webhook
+  │
+  ▼
+Cloud Function  (validate the webhook secret, map instance → connector_id, publish to Pub/Sub, return 200)
   │
   ▼  Pub/Sub → Eventarc
-Cloud Workflow  (orchestrate the drain):
-     determine_sync_status(connector)
-       ├─ broken/paused → update_connector(resume); if still failing → escalate, stop
-       └─ healthy       → trigger_sync(connector, force=true)
-     enforce cooldown / max-attempts; escalate if N consecutive fires do not reduce the slot
+Cloud Workflow  (drain orchestration — see Section 4)
+  │
   ▼
-Fivetran  → sync advances restart_lsn → WAL released → slot drains → monitor recovers
+Fivetran  →  sync advances restart_lsn  →  WAL released  →  slot drains
 ```
 
-### Why this shape (and not a poller)
+The mechanism does **not** poll for slot fullness — DevOps's monitor detects the threshold and
+pushes the trigger in. There is no DSE-side database access to the RDS primaries.
 
-- DOT's documented pattern is **push-not-poll**: thin Cloud Functions publish to Pub/Sub;
-  Cloud Workflows orchestrate. A scheduled poller that queries `pg_replication_slots`
-  directly would contradict that pattern and would require granting DOT credentialed network
-  access to three production RDS primaries — a new, sensitive surface this design avoids.
-- The metric, the CloudWatch→Datadog pipeline, and the 70% escalation monitor already exist
-  or are trivial to add; the valve reuses them.
-- The ~5–15 minute metric staleness is immaterial at a 50%-of-cap trigger with hours of
-  runway. Fill-rate (`aws.rds.transaction_logs_generation`) should be checked per instance to
-  confirm runway from 50% to 100% comfortably exceeds the metric lag plus a sync duration; if
-  any instance's runway is too short, raise the trigger cadence or revisit a real-time read.
+## 4. Drain orchestration (the state machine)
 
-## 5. Drain mechanism and existing primitives
+On each trigger, the Workflow inspects connector state via `fivetran_client`
+(`determine_sync_status`, `get_connector_details`) and branches:
 
-A forced Fivetran sync reads the slot and advances `restart_lsn`, releasing retained WAL:
-`POST /v1/connectors/{connector_id}/sync` with `{"force": true}`.
+| Connector state | Action |
+|---|---|
+| A sync is **already running** | **No-op.** A drain is already in progress; firing again would stack redundant syncs (handles both cooldown and duplicate triggers from monitor re-fire / at-least-once Pub/Sub delivery). |
+| **Paused** | **Resume** (`update_connector(paused=False)`), then force-sync. A paused connector cannot accept an API-triggered sync. |
+| **Broken** (auth / schema failure — not merely paused) | **Stop.** A force-sync will not drain a broken connector. Emit a structured failure signal and let DevOps's escalation handle continued slot growth. Do not attempt a futile sync or a repair. |
+| **Healthy** | **Force-sync** via `trigger_sync(connector_id, force=True)`. |
 
-`fivetran-trigger/fivetran_client.py` already provides the needed primitives:
+Two properties this guarantees:
 
-- `trigger_sync(connector_id, force=True)` — the drain.
-- `determine_sync_status(connector_id)` — the broken/paused-connector guard.
-- `update_connector(...)` — resume a paused connector.
-- `get_connector_details(connector_id)` — state inspection.
+- **Schedule-neutral.** The mechanism calls `trigger_sync` directly and must **not** route
+  through the existing `fivetran-trigger` Cloud Function entry point, which sets
+  `schedule_type: "manual"` on every invocation. Mutating the schedule as a side effect would
+  undermine the connectors' native scheduling (and the frequency change in Section 6). The
+  only connector mutation the mechanism performs is resuming a paused connector.
+- **A forced sync is not proof of a drain.** A `200` from the force call does not guarantee
+  WAL was released — a sync already in flight, or a long historical re-sync (e.g. on
+  history-mode tables), may not advance `restart_lsn` immediately. The mechanism confirms only
+  that the sync was **accepted/initiated**; whether the slot actually fell is confirmed by
+  **DevOps's metric** (their monitor simply re-fires if it did not drain). The mechanism does
+  not re-implement metric-watching.
 
-The valve is therefore mostly orchestration around existing client code, not new Fivetran
-integration.
+## 5. Drain endpoint
 
-## 6. Required guards
+`fivetran_client.trigger_sync(connector_id, force=True)` issues
+`POST /v1/connectors/{connector_id}/force` with body `{"force": true}`. The client already
+provides every primitive the mechanism needs: `trigger_sync`, `determine_sync_status`,
+`update_connector`, `get_connector_details`.
 
-| Guard | Why |
-|-------|-----|
-| Broken/paused-connector check before sync (`determine_sync_status`) | A paused or broken connector (schema change, auth failure — the usual cause of runaway growth) will not drain on a forced sync. Attempt resume-then-sync; if the sync fails, escalate to the human monitor rather than retrying indefinitely. |
-| Cooldown / max-attempts | A slot stays "full" until the drain sync completes and Postgres releases WAL. Without a cooldown the trigger re-fires every evaluation window and hammers the Fivetran API. The cooldown must exceed a typical sync duration for the connector. |
-| Monitor hysteresis | The monitor's recovery threshold sits below 50% so it does not flap around the trigger. |
-| Escalate after N ineffective fires | If repeated valve syncs do not reduce the slot, the real fix is a connector repair or a higher sync cadence — page a human. |
-| Webhook authentication | The Cloud Function validates the Datadog webhook secret on inbound. |
+## 6. Coupled change: sync-frequency reduction (later, not part of the valve)
 
-## 7. Interaction with DT-511
+The 2026-06-16 review also agreed to reduce these connectors' scheduled sync frequency once
+the valve is in place — a sparser schedule is safe precisely because the valve catches slot
+growth between syncs. Sequence: land and prove the valve first, then relax `sync_frequency`
+(via fivetran-as-code or a connector PATCH).
 
-The `fivetran_dbt` Workflow fires the downstream dbt build on `sync_end` regardless of sync
-success. A valve-triggered sync emits `sync_end` and therefore fires the domain build:
+Headroom is large, so this is low-risk: source-freshness tolerances are wide (MPDX
+`warn 1d / error 10d`; Global Registry and Global Registry Flat `warn 7d / error 14d`), the
+connectors currently sync hourly, and the downstream warehouse builds run on their own
+schedules. Downstream dbt builds are intentionally **decoupled** from Fivetran `sync_end`
+(they run on independent schedules to control BigQuery cost), so valve-triggered syncs do not
+fan out extra builds, and the `fivetran_dbt`/`sync_end` interaction (DT-511) does not apply
+here. The safe minimum sync frequency is therefore bounded by each connector's downstream
+build time, not by the current hourly cadence.
 
-- **Extra builds** each time the valve fires (cost). Acceptable if the valve is rare; if it
-  fires often, consider a drain path that does not trigger the downstream build. Decide once
-  the real valve frequency is observed.
-- **Failed-sync fan-out:** if a valve sync fails on a broken connector, DT-511's behavior
-  fires the downstream build on a failed sync. The broken-connector guard (Section 6)
-  mitigates by escalating instead of repeatedly syncing, but the first failed valve sync
-  would still trip DT-511. Resolving DT-511 also benefits this design.
+## 7. Open items / to-dos
 
-## 8. Sync-frequency reduction (coupled change)
+1. **Confirm `global-registry-prod`'s Fivetran connector.** Only `mpdx-api-prod`
+   (`loft_unabashed`) and `global-registry-flat-prod` (`freebee_tuberculosis`) are wired in
+   the DOT scheduler today; `global-registry-prod` has no connector mapped there. Locating /
+   confirming it is a cleanup to-do, not a design blocker.
+2. Decide where the orchestration lives — extend `fivetran-trigger/` (which holds the client)
+   or a dedicated Workflow — consistent with the push pattern and schedule-neutrality.
+3. Sequence the sync-frequency reduction after the valve is proven (Section 6).
 
-The 2026-06-16 review framed two coupled changes: reduce the scheduled Fivetran sync
-frequency on these connectors, and add this valve. The valve is what makes a sparser schedule
-safe — it catches slot growth that a less frequent schedule would otherwise let approach the
-cap. Sequence: land and prove the valve first, then relax `sync_frequency`. Reducing
-frequency also reduces downstream build load (the `fivetran_dbt` Workflow fires builds on
-`sync_end`); confirm the new cadence still meets warehouse-freshness needs for the data these
-three connectors feed (MPDX, Global Registry, Global Registry Flat).
+## 8. Implementation outline (DSE scope)
 
-## 9. Open items
-
-1. Confirm the Fivetran connector that maps to each RDS instance (Section 2).
-2. Reconcile the 70% escalation monitor with whatever already exists in the reference
-   notebook; define the 50% valve monitors per instance.
-3. Confirm where the valve orchestration lives — extend `fivetran-trigger/` (which holds the
-   client) or a dedicated Workflow — consistent with the push-not-poll stack.
-4. Choose the cooldown/attempt-tracking mechanism (Workflow state, a small datastore record,
-   or a pre-sync `determine_sync_status` check).
-5. Decide whether valve syncs should trigger downstream dbt builds (DT-511 coupling).
-6. Sequence the sync-frequency reduction after the valve is proven (Section 8).
-7. Per-instance fill-rate check to confirm runway from 50% to 100% comfortably exceeds metric
-   lag plus sync duration (Section 4).
-
-## 10. Implementation outline (once open items are settled)
-
-- [ ] Confirm connector ↔ instance mapping.
-- [ ] Escalation: Datadog monitor at 70% of cap per instance → `@devops-engineering-team`.
-- [ ] Valve monitor: Datadog monitor at 50% of cap per instance → webhook.
-- [ ] Cloud Function: validate webhook, map instance → connector, publish to Pub/Sub.
-- [ ] Cloud Workflow: `determine_sync_status` → resume if paused → `trigger_sync(force=true)`
-      → escalate on failure; enforce cooldown / max-attempts.
-- [ ] Decide downstream-build behavior for valve syncs (DT-511).
-- [ ] Test: drive a slot toward 50% (or simulate the metric) → valve fires → slot drains →
-      monitor recovers; verify cooldown and broken-connector escalation.
-- [ ] Runbook entry: response when the valve escalates (slot not draining).
-- [ ] After the valve is proven: relax `sync_frequency` on the three connectors and confirm
-      warehouse freshness holds.
+- [ ] Hard-coded, reviewed instance → connector_id map (confirm `global-registry-prod`).
+- [ ] Cloud Function: validate the webhook secret, map instance → connector, publish to Pub/Sub.
+- [ ] Cloud Workflow drain orchestration (Section 4): state check → no-op / resume+sync / stop / force-sync; schedule-neutral; emit a structured failure signal on the broken-connector path for DevOps's alerting.
+- [ ] Confirm with DevOps the trigger contract (webhook payload + secret) their 50% monitor will send.
+- [ ] Test: drive a slot toward 50% (or simulate the trigger) → mechanism force-syncs → slot drains; verify the no-op-while-syncing, paused-resume, and broken-connector-stop branches.
+- [ ] Runbook note (DSE side): what the broken-connector failure signal means and how to act on it.
+- [ ] After the valve is proven: relax `sync_frequency` on the connectors (Section 6).

--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -1,6 +1,6 @@
 # Design: Fivetran Replication-Slot Safety-Valve Sync (DSE mechanism)
 
-**Status:** Draft — 2026-06-17
+**Status:** Reviewed — 2026-06-18. Approved by the architect (Matt Drees) on dot PR #103; DevOps reviewing the webhook PR (cru-terraform #10907). Review decisions are resolved in Section 9.
 **Origin:** Agreed approach from the 2026-06-16 replication-slot review (Data Engineering + DevOps Engineering). This plan is the result of that discussion.
 **Reference:** Datadog notebook 14785624 — "Fivetran Slot Safety Valve: Metrics, Limits & Trigger Thresholds" holds the metric, the per-instance caps, and the threshold rationale. Companion pipeline view: notebook 14785154.
 
@@ -144,16 +144,15 @@ Evolve `fivetran-trigger` into one component handling scheduled *and* event-driv
 shared guards, as part of the "all connectors DOT-scheduled" direction (Section 8).
 - **Pros:** strategically coherent — addresses the valve and the scheduling migration
   together; one home for all Fivetran sync logic with guards; the right place for "set
-  `manual` conditionally," and the natural home for the recency-skip "adaptive cadence" in
-  Section 7 (which needs the same last-sync state-check shared across the scheduled and valve
-  paths).
+  `manual` conditionally."
 - **Cons:** much larger scope; couples the (contained) valve to a broader refactor; needs the
   most design and review time.
 
-**Open decision:** ship **B now and converge to C later** (the valve Workflow becomes a
-building block of the unified orchestrator), or commit to **C from the start**. Option A is
-viable only if the guards in Section 5 are judged unnecessary. This is the decision to settle
-in review.
+**Decision (review, 2026-06-18): Option B.** Ship the dedicated guarded valve component.
+Converging to a unified orchestrator (C) is **not** pursued — the architect judged its added
+complexity (including the adaptive-cadence idea that motivated it) not worth it. Option A is
+rejected: the Section 5 guards are needed and don't belong bolted onto the shared
+scheduled-trigger path.
 
 ## 7. Coupled change: sync-frequency reduction (later)
 
@@ -166,21 +165,29 @@ Headroom is large, so this is low-risk: source-freshness tolerances are wide (MP
 connectors currently sync hourly, and the downstream warehouse builds run on their own
 schedules. Downstream dbt builds are intentionally decoupled from Fivetran `sync_end` (they
 run on independent schedules to control BigQuery cost), so valve-triggered syncs do not fan
-out extra builds. The safe minimum sync frequency is bounded by each connector's downstream
-build time, not by the current hourly cadence.
+out extra builds. **Decision (review): reduce to once per day — not less than daily.** Daily
+sits well inside the freshness tolerances above, and the architect set daily as the floor.
 
-**Adaptive cadence (optional enhancement).** A valve-triggered sync also refreshes the data,
-so a scheduled sync that fires shortly after is redundant. The scheduled trigger can be made
-*recency-aware*: before syncing, check the connector's last successful sync (`fivetran_client`
-already exposes it) and skip if it occurred within the interval — e.g. a valve sync at 9:50
-makes the 10:00 scheduled tick a no-op. This is the same last-sync state-check the valve's
-in-progress guard uses, applied to the scheduled path, giving a self-trimming cadence (sync on
-schedule *unless* a sync — scheduled or valve — already ran recently) rather than literally
-rescheduling the cron, which Cloud Scheduler does not support cleanly. It is an optimization,
-not load-bearing — a redundant incremental sync is cheap and downstream builds are decoupled —
-and because it wants the recency logic shared across the scheduled and valve paths, it favors
-the unified orchestrator (Section 6, Option C). The skip window should be tied to the interval
-(skip the immediately-following tick, not one that is legitimately due).
+**Schedule placement (the chosen cost mitigation).** Place each daily sync **outside the
+connector's high-churn window**, so a scheduled sync and a valve-triggered sync never run
+back-to-back (two Fivetran→BigQuery merges in quick succession). For **MPDX** — the only
+high-volume connector (the Fivetran logs show ≈10.4M rows/day extracted vs ~123k for
+Global Registry Flat and ~4.5k for Global Registry) — the churn peak is **09–14 UTC
+(≈5–10am ET)** at 600–700k rows/sync, with a quiet evening/overnight window
+(≈3.7–18k rows/sync). The slot is most likely to approach the valve threshold during that
+peak, so scheduling the daily sync in the quiet window keeps the scheduled drain and any valve
+drain hours apart. (Time-of-day does not change a *daily* sync's volume — it ships the full
+day's WAL whenever it runs — so this is purely about separating the two drains, not reducing
+the pull.)
+
+**Cost rationale.** Fivetran's own price is MAR (monthly *unique* active rows) and is
+frequency-neutral; the large MAR/BigQuery spikes come from re-snapshots (the logs show a single
+352M-row re-import in 60 days), which the valve exists to prevent. The cost that scales with
+sync count is the Fivetran→BigQuery load+merge each sync runs — so hourly→daily (≈24× fewer
+merges) is the real BigQuery saving, and schedule placement removes the occasional extra
+back-to-back merge. An "adaptive cadence" (skip-the-scheduled-sync-if-one-just-ran) was
+considered and **dropped**: it saves only that same occasional merge while trading away
+schedule predictability — schedule placement achieves the cost goal without the added logic.
 
 ## 8. Coupled cleanup: migrate connectors to DOT scheduling
 
@@ -210,18 +217,20 @@ This is a separate workstream that the valve depends on for `global-registry-pro
 connector must be migrated to DOT scheduling (add to the `fivetran_trigger` block, set
 `manual`) before the valve can drain it cleanly.
 
-## 9. Open items / decisions for review
+## 9. Decisions (resolved in review, 2026-06-18)
 
-1. **Orchestration placement (Section 6):** B-now-converge-to-C vs. C-from-the-start. The
-   central decision.
-2. **Trigger contract (Section 3):** define the valve trigger (a 50%-of-cap monitor or a
-   webhook on an existing monitor) and the payload it sends to the mechanism.
-3. **Connector scheduling migration (Section 8):** migrate `centralized_mitigation` (and the
-   wider `auto` list) to DOT scheduling; sequence relative to the valve.
-4. **Frequency reduction (Section 7):** sequence after the valve is proven.
-5. **Adaptive cadence (Section 7):** optional recency-skip so a scheduled sync no-ops when the
-   valve (or a recent scheduled run) already synced. An optimization; favors Option C (shared
-   recency logic across the scheduled and valve paths).
+Settled with the architect (Matt Drees), who approved the PR on this basis:
+
+1. **Orchestration (Section 6): Option B** — a dedicated guarded valve component. Not
+   converging to a unified orchestrator (C).
+2. **Trigger contract (Section 3): 50% of cap.** Webhook payload = a simple slug (the instance
+   id, e.g. `mpdx-api-prod`); DOT maps the slug to the Fivetran connector.
+3. **Connector migration (Section 8): migrate the Fivetran-native (`auto`) connectors to DOT
+   scheduling in bulk** (not piecemeal).
+4. **Frequency (Section 7): reduce to once per day — not less than daily.**
+5. **Adaptive cadence: dropped** in favor of schedule placement (Section 7).
+
+Remaining work is the implementation outline below (Section 10).
 
 ## 10. Implementation outline (DSE scope)
 
@@ -233,5 +242,7 @@ connector must be migrated to DOT scheduling (add to the `fivetran_trigger` bloc
 - [ ] Test: drive a slot toward the trigger (or simulate it) → mechanism force-syncs → slot
       drains; verify the already-syncing, paused-resume, and broken-stop branches.
 - [ ] Runbook note (DSE side): what the broken-connector failure signal means and how to act.
-- [ ] Migrate `global-registry-prod` (`centralized_mitigation`) to DOT scheduling (Section 8).
-- [ ] After the valve is proven: relax `sync_frequency` on the connectors (Section 7).
+- [ ] Migrate the Fivetran-native (`auto`) connectors to DOT scheduling **in bulk** (Section 8),
+      including the valve's `centralized_mitigation` (`global-registry-prod`).
+- [ ] After the valve is proven: reduce `sync_frequency` to **daily**, each connector's run
+      placed **outside its high-churn window** (Section 7).

--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -1,0 +1,185 @@
+# Design: Fivetran / RDS Replication-Slot Safety Valve
+
+**Status:** Draft — 2026-06-17
+**Origin:** Action item from the 2026-06-16 replication-slot review (Data Engineering + DevOps Engineering).
+**Reference:** Datadog notebook 14785624 — "Fivetran Slot Safety Valve: Metrics, Limits & Trigger Thresholds" (owner `team:devops-engineering-team`). Companion pipeline view: notebook 14785154.
+**Related:** [DT-511](https://jira.cru.org/browse/DT-511) (the `fivetran_dbt` Workflow fires the downstream dbt build on `sync_end` regardless of sync success).
+
+---
+
+## 1. Problem
+
+Three production AWS RDS Postgres instances feed the warehouse through Fivetran via logical
+replication. Each Fivetran `pgoutput` replication slot retains write-ahead log (WAL) on the
+RDS primary until Fivetran consumes it — a sync advances the slot's `restart_lsn` and
+releases the retained WAL. Between syncs, or when a connector is paused or broken, retained
+WAL accumulates.
+
+Each instance has a hard cap (`max_slot_wal_keep_size`, set in cru-terraform). When retained
+WAL reaches the cap, Postgres invalidates the slot and Fivetran must perform a full
+re-snapshot. That invalidation is the mechanism behind the recurring "Invalid Replication
+Slot" connector breaks. The cap protects database storage (no outage), but invalidation plus
+full re-sync is disruptive and costly, and it is silent until it happens.
+
+**Goal:** automatically drain a slot — by forcing a Fivetran sync — when retained WAL
+approaches the cap, before invalidation occurs; and escalate to a human when a forced sync
+cannot drain it (the paused/broken-connector case). A reliable valve also makes it safe to
+relax sync schedules without risking slot invalidation.
+
+## 2. Metric, targets, and limits
+
+### Metric
+
+| Metric | Use |
+|--------|-----|
+| `aws.rds.oldest_replication_slot_lag` | **Primary** — bytes of WAL retained by the most-lagging slot (the Fivetran `pgoutput` slot). Filter by `dbinstanceidentifier`; compare against the cap. |
+| `aws.rds.transaction_logs_generation` | WAL fill-rate (bytes/sec) — estimate time-to-cap. |
+| `aws.rds.transaction_logs_disk_usage` | Secondary — total WAL on disk (slot + checkpoint). |
+
+`aws.rds.oldest_logical_replication_slot_lag` (returns −1 / unreliable on these instances)
+and `aws.rds.replication_slot_disk_usage` (slot state files, ~8 KB — not WAL retained) must
+not be used.
+
+The metric is in **bytes**, not a percentage; the percentage of cap is computed per
+instance. The Datadog value is CloudWatch-polled and is therefore ~5–15 minutes stale, which
+is acceptable at a 50%-of-cap trigger that has hours of runway.
+
+### Targets and caps (`max_slot_wal_keep_size`, verified in cru-terraform)
+
+| Instance (`dbinstanceidentifier`) | Cap | Cap (MB / bytes) | cru-terraform source |
+|------|-----|------|------|
+| `mpdx-api-prod` | 100 GiB | 102400 / 107,374,182,400 | `applications/mpdx/api/prod/locals.tf` |
+| `global-registry-prod` | 75 GiB | 76800 / 80,530,636,800 | `applications/global-registry/prod/locals.tf` |
+| `global-registry-flat-prod` | 75 GiB | 76800 / 80,530,636,800 | `applications/global-registry/prod/locals.tf` |
+
+The Fivetran connector that maps to each instance must be confirmed against the Fivetran
+account and DOT configuration before implementation (see Section 8).
+
+## 3. Thresholds (percentage of each instance's cap)
+
+| Tier | % of cap | MPDX | Global Registry (both) | Action |
+|------|----------|------|------------------------|--------|
+| Auto-trigger (valve) | 50% | 50 GiB | 37.5 GiB | force a Fivetran sync to drain the slot |
+| Human escalation | ~70% | 70 GiB | 50 GiB | notify `@devops-engineering-team@cru.org` |
+| Hard cap (invalidation) | 100% | 100 GiB | 75 GiB | slot dropped → full re-sync (the backstop) |
+
+The valve at 50% self-heals before the 70% human monitor fires. RDS storage autoscaling and
+the cap remain the ultimate backstop below all of this.
+
+## 4. Architecture (decision: 2026-06-17)
+
+**Decision:** a hybrid that fits DOT's existing push-not-poll architecture (see
+`ARCHITECTURE.md`) and adds no new direct database access:
+
+- **Escalation (70%):** a Datadog monitor on `aws.rds.oldest_replication_slot_lag` per
+  instance, notifying `@devops-engineering-team@cru.org`. Pure monitoring, DevOps-owned;
+  partially defined already in the reference notebook.
+- **Valve (50%):** a Datadog monitor at 50% of cap → webhook → thin Cloud Function
+  (validate + publish to Pub/Sub) → Cloud Workflow (orchestration: status check → resume →
+  force-sync → escalate-on-failure, with cooldown). This is exactly the standard DOT flow.
+
+```
+RDS → CloudWatch → Datadog  (aws.rds.oldest_replication_slot_lag, by dbinstanceidentifier)
+  │  datadog_monitor: lag > 50% of cap (per instance)
+  ▼  webhook
+Cloud Function  (validate webhook, classify instance→connector, publish to Pub/Sub, return 200)
+  │
+  ▼  Pub/Sub → Eventarc
+Cloud Workflow  (orchestrate the drain):
+     determine_sync_status(connector)
+       ├─ broken/paused → update_connector(resume); if still failing → escalate, stop
+       └─ healthy       → trigger_sync(connector, force=true)
+     enforce cooldown / max-attempts; escalate if N consecutive fires do not reduce the slot
+  ▼
+Fivetran  → sync advances restart_lsn → WAL released → slot drains → monitor recovers
+```
+
+### Why this shape (and not a poller)
+
+- DOT's documented pattern is **push-not-poll**: thin Cloud Functions publish to Pub/Sub;
+  Cloud Workflows orchestrate. A scheduled poller that queries `pg_replication_slots`
+  directly would contradict that pattern and would require granting DOT credentialed network
+  access to three production RDS primaries — a new, sensitive surface this design avoids.
+- The metric, the CloudWatch→Datadog pipeline, and the 70% escalation monitor already exist
+  or are trivial to add; the valve reuses them.
+- The ~5–15 minute metric staleness is immaterial at a 50%-of-cap trigger with hours of
+  runway. Fill-rate (`aws.rds.transaction_logs_generation`) should be checked per instance to
+  confirm runway from 50% to 100% comfortably exceeds the metric lag plus a sync duration; if
+  any instance's runway is too short, raise the trigger cadence or revisit a real-time read.
+
+## 5. Drain mechanism and existing primitives
+
+A forced Fivetran sync reads the slot and advances `restart_lsn`, releasing retained WAL:
+`POST /v1/connectors/{connector_id}/sync` with `{"force": true}`.
+
+`fivetran-trigger/fivetran_client.py` already provides the needed primitives:
+
+- `trigger_sync(connector_id, force=True)` — the drain.
+- `determine_sync_status(connector_id)` — the broken/paused-connector guard.
+- `update_connector(...)` — resume a paused connector.
+- `get_connector_details(connector_id)` — state inspection.
+
+The valve is therefore mostly orchestration around existing client code, not new Fivetran
+integration.
+
+## 6. Required guards
+
+| Guard | Why |
+|-------|-----|
+| Broken/paused-connector check before sync (`determine_sync_status`) | A paused or broken connector (schema change, auth failure — the usual cause of runaway growth) will not drain on a forced sync. Attempt resume-then-sync; if the sync fails, escalate to the human monitor rather than retrying indefinitely. |
+| Cooldown / max-attempts | A slot stays "full" until the drain sync completes and Postgres releases WAL. Without a cooldown the trigger re-fires every evaluation window and hammers the Fivetran API. The cooldown must exceed a typical sync duration for the connector. |
+| Monitor hysteresis | The monitor's recovery threshold sits below 50% so it does not flap around the trigger. |
+| Escalate after N ineffective fires | If repeated valve syncs do not reduce the slot, the real fix is a connector repair or a higher sync cadence — page a human. |
+| Webhook authentication | The Cloud Function validates the Datadog webhook secret on inbound. |
+
+## 7. Interaction with DT-511
+
+The `fivetran_dbt` Workflow fires the downstream dbt build on `sync_end` regardless of sync
+success. A valve-triggered sync emits `sync_end` and therefore fires the domain build:
+
+- **Extra builds** each time the valve fires (cost). Acceptable if the valve is rare; if it
+  fires often, consider a drain path that does not trigger the downstream build. Decide once
+  the real valve frequency is observed.
+- **Failed-sync fan-out:** if a valve sync fails on a broken connector, DT-511's behavior
+  fires the downstream build on a failed sync. The broken-connector guard (Section 6)
+  mitigates by escalating instead of repeatedly syncing, but the first failed valve sync
+  would still trip DT-511. Resolving DT-511 also benefits this design.
+
+## 8. Sync-frequency reduction (coupled change)
+
+The 2026-06-16 review framed two coupled changes: reduce the scheduled Fivetran sync
+frequency on these connectors, and add this valve. The valve is what makes a sparser schedule
+safe — it catches slot growth that a less frequent schedule would otherwise let approach the
+cap. Sequence: land and prove the valve first, then relax `sync_frequency`. Reducing
+frequency also reduces downstream build load (the `fivetran_dbt` Workflow fires builds on
+`sync_end`); confirm the new cadence still meets warehouse-freshness needs for the data these
+three connectors feed (MPDX, Global Registry, Global Registry Flat).
+
+## 9. Open items
+
+1. Confirm the Fivetran connector that maps to each RDS instance (Section 2).
+2. Reconcile the 70% escalation monitor with whatever already exists in the reference
+   notebook; define the 50% valve monitors per instance.
+3. Confirm where the valve orchestration lives — extend `fivetran-trigger/` (which holds the
+   client) or a dedicated Workflow — consistent with the push-not-poll stack.
+4. Choose the cooldown/attempt-tracking mechanism (Workflow state, a small datastore record,
+   or a pre-sync `determine_sync_status` check).
+5. Decide whether valve syncs should trigger downstream dbt builds (DT-511 coupling).
+6. Sequence the sync-frequency reduction after the valve is proven (Section 8).
+7. Per-instance fill-rate check to confirm runway from 50% to 100% comfortably exceeds metric
+   lag plus sync duration (Section 4).
+
+## 10. Implementation outline (once open items are settled)
+
+- [ ] Confirm connector ↔ instance mapping.
+- [ ] Escalation: Datadog monitor at 70% of cap per instance → `@devops-engineering-team`.
+- [ ] Valve monitor: Datadog monitor at 50% of cap per instance → webhook.
+- [ ] Cloud Function: validate webhook, map instance → connector, publish to Pub/Sub.
+- [ ] Cloud Workflow: `determine_sync_status` → resume if paused → `trigger_sync(force=true)`
+      → escalate on failure; enforce cooldown / max-attempts.
+- [ ] Decide downstream-build behavior for valve syncs (DT-511).
+- [ ] Test: drive a slot toward 50% (or simulate the metric) → valve fires → slot drains →
+      monitor recovers; verify cooldown and broken-connector escalation.
+- [ ] Runbook entry: response when the valve escalates (slot not draining).
+- [ ] After the valve is proven: relax `sync_frequency` on the three connectors and confirm
+      warehouse freshness holds.

--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -144,7 +144,9 @@ Evolve `fivetran-trigger` into one component handling scheduled *and* event-driv
 shared guards, as part of the "all connectors DOT-scheduled" direction (Section 8).
 - **Pros:** strategically coherent — addresses the valve and the scheduling migration
   together; one home for all Fivetran sync logic with guards; the right place for "set
-  `manual` conditionally."
+  `manual` conditionally," and the natural home for the recency-skip "adaptive cadence" in
+  Section 7 (which needs the same last-sync state-check shared across the scheduled and valve
+  paths).
 - **Cons:** much larger scope; couples the (contained) valve to a broader refactor; needs the
   most design and review time.
 
@@ -166,6 +168,19 @@ schedules. Downstream dbt builds are intentionally decoupled from Fivetran `sync
 run on independent schedules to control BigQuery cost), so valve-triggered syncs do not fan
 out extra builds. The safe minimum sync frequency is bounded by each connector's downstream
 build time, not by the current hourly cadence.
+
+**Adaptive cadence (optional enhancement).** A valve-triggered sync also refreshes the data,
+so a scheduled sync that fires shortly after is redundant. The scheduled trigger can be made
+*recency-aware*: before syncing, check the connector's last successful sync (`fivetran_client`
+already exposes it) and skip if it occurred within the interval — e.g. a valve sync at 9:50
+makes the 10:00 scheduled tick a no-op. This is the same last-sync state-check the valve's
+in-progress guard uses, applied to the scheduled path, giving a self-trimming cadence (sync on
+schedule *unless* a sync — scheduled or valve — already ran recently) rather than literally
+rescheduling the cron, which Cloud Scheduler does not support cleanly. It is an optimization,
+not load-bearing — a redundant incremental sync is cheap and downstream builds are decoupled —
+and because it wants the recency logic shared across the scheduled and valve paths, it favors
+the unified orchestrator (Section 6, Option C). The skip window should be tied to the interval
+(skip the immediately-following tick, not one that is legitimately due).
 
 ## 8. Coupled cleanup: migrate connectors to DOT scheduling
 
@@ -204,6 +219,9 @@ connector must be migrated to DOT scheduling (add to the `fivetran_trigger` bloc
 3. **Connector scheduling migration (Section 8):** migrate `centralized_mitigation` (and the
    wider `auto` list) to DOT scheduling; sequence relative to the valve.
 4. **Frequency reduction (Section 7):** sequence after the valve is proven.
+5. **Adaptive cadence (Section 7):** optional recency-skip so a scheduled sync no-ops when the
+   valve (or a recent scheduled run) already synced. An optimization; favors Option C (shared
+   recency logic across the scheduled and valve paths).
 
 ## 10. Implementation outline (DSE scope)
 

--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -51,11 +51,16 @@ consequences for this design:
   a human is paged so it can self-heal; the notebook proposes 50% of cap. The existing
   monitors start at 70% (warning). A trigger at the valve threshold that **invokes the DSE
   mechanism** does not exist yet.
-- **The trigger contract is the open DSE-to-detection interface.** The current monitors only
-  email DevOps; none calls a webhook into the DSE mechanism. Whoever owns detection must wire
-  a notification (a 50%-of-cap monitor, or a webhook on an existing one) to the mechanism's
-  endpoint, with an agreed payload (at minimum the `dbinstanceidentifier`, from which the
-  mechanism resolves the connector). Defining that contract is a prerequisite to building.
+- **The trigger contract is a shared DSE-to-detection interface, not a solo task.** The
+  current monitors only email DevOps; none calls into the DSE mechanism. The likely shape is
+  a **dedicated Datadog monitor at the valve threshold** (the notebook's ~50% of cap, below
+  the 70% human warning) whose **webhook notification** invokes the mechanism — Datadog
+  supports `@webhook-…` notifications natively, so this is a well-understood piece, not an
+  open research problem. The split: **detection owns the monitor and points its webhook at
+  the mechanism's endpoint; DSE owns the endpoint and the payload spec** (at minimum the
+  `dbinstanceidentifier`, from which the mechanism resolves the connector). What the webhook
+  ultimately calls depends on the orchestration-placement decision in Section 6. Agreeing the
+  endpoint + payload is a prerequisite to building.
 
 ## 4. Targets and connector mapping (verified via the Fivetran API)
 

--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -2,11 +2,11 @@
 
 **Status:** Draft — 2026-06-17
 **Origin:** Agreed approach from the 2026-06-16 replication-slot review (Data Engineering + DevOps Engineering). This plan is the result of that discussion.
-**Reference:** Datadog notebook 14785624 — "Fivetran Slot Safety Valve: Metrics, Limits & Trigger Thresholds" (owner `team:devops-engineering-team`) holds the metric, the per-instance caps, and the 50% / 70% / 100% thresholds. Companion pipeline view: notebook 14785154.
+**Reference:** Datadog notebook 14785624 — "Fivetran Slot Safety Valve: Metrics, Limits & Trigger Thresholds" holds the metric, the per-instance caps, and the threshold rationale. Companion pipeline view: notebook 14785154.
 
 ---
 
-## 1. Scope and ownership boundary
+## 1. Problem
 
 Three production AWS RDS Postgres instances feed the warehouse through Fivetran via logical
 replication. Each Fivetran `pgoutput` replication slot retains write-ahead log (WAL) on the
@@ -17,122 +17,198 @@ behind the recurring "Invalid Replication Slot" connector breaks. The cap protec
 storage (no outage), but invalidation plus full re-sync is disruptive, and it is silent until
 it happens.
 
-The agreed remedy is a safety valve: when retained WAL reaches **50% of an instance's cap**,
-automatically force a Fivetran sync to drain the slot before it can approach invalidation.
+The agreed remedy is a safety valve: when a slot's retained WAL crosses a trigger threshold,
+automatically force a Fivetran sync to drain it before it can approach invalidation.
+
+## 2. Scope and ownership boundary
 
 **This document covers only the Data Engineering piece: the mechanism that runs the Fivetran
-sync when a slot reaches 50%.** Everything else is owned by DevOps Engineering and handled
-through their standard process:
+sync when a slot crosses the trigger threshold.** The detection, thresholds, monitors, and
+human escalation are owned by DevOps Engineering and handled through their standard process.
 
 | Owned by **DevOps Engineering** (not specified here) | Owned by **Data Engineering** (this doc) |
 |---|---|
-| The RDS instances and the `max_slot_wal_keep_size` caps | The mechanism that, on the 50% trigger, runs a Fivetran sync to drain the slot |
-| The Datadog metric, the 50% / 70% / 100% thresholds, and the monitors | Connector-state handling around that sync (resume / no-op / stop) |
-| Detection at 50% and the call to the DSE mechanism | Not mutating connector scheduling as a side effect |
-| Human escalation (70%) and all alerting | Emitting a structured failure signal for DevOps's alerting to consume |
+| The RDS instances and the `max_slot_wal_keep_size` caps | The mechanism that, on the trigger, runs a Fivetran sync to drain the slot |
+| The Datadog metric, the thresholds, and the monitors | Connector-state handling around that sync (resume / no-op / stop) |
+| Human escalation and all alerting | Not mutating connector scheduling as a side effect |
+| The signal/trigger that invokes the DSE mechanism | Emitting a structured failure signal for DevOps's alerting to consume |
 
-DevOps's monitor detects the 50% threshold and invokes the DSE mechanism. The mechanism's job
-is to drain the slot via Fivetran; it does not own detection, thresholds, or escalation.
+## 3. Detection today (DevOps-owned) and the trigger-contract gap
 
-## 2. Targets
+DevOps has created three Datadog monitors on `aws.rds.oldest_replication_slot_lag`
+(one per instance), notifying `@devops-engineering-team@cru.org`:
 
-| RDS instance (`dbinstanceidentifier`) | Fivetran connector | Source (cru-terraform) |
-|------|------|------|
-| `mpdx-api-prod` | `loft_unabashed` | `applications/mpdx/api/prod/locals.tf` |
-| `global-registry-flat-prod` | `freebee_tuberculosis` | `applications/global-registry/prod/locals.tf` |
-| `global-registry-prod` | **to confirm** (see Section 7) | `applications/global-registry/prod/locals.tf` |
+| Monitor (instance) | Cap | Warning | Critical |
+|---|---|---|---|
+| Production MPDX (`mpdx-api-prod`) | 100 GiB | 70% (70 GiB) | 90% (90 GiB) |
+| Production Global Registry (`global-registry-prod`) | 75 GiB | 70% (52.5 GiB) | 90% (67.5 GiB) |
+| Production Global Registry Flat (`global-registry-flat-prod`) | 75 GiB | 70% (52.5 GiB) | 90% (67.5 GiB) |
+
+These are **human-escalation** monitors ("investigate and resume the connector"). Two
+consequences for this design:
+
+- **The valve needs its own trigger, below the human warning.** The valve must fire *before*
+  a human is paged so it can self-heal; the notebook proposes 50% of cap. The existing
+  monitors start at 70% (warning). A trigger at the valve threshold that **invokes the DSE
+  mechanism** does not exist yet.
+- **The trigger contract is the open DSE-to-detection interface.** The current monitors only
+  email DevOps; none calls a webhook into the DSE mechanism. Whoever owns detection must wire
+  a notification (a 50%-of-cap monitor, or a webhook on an existing one) to the mechanism's
+  endpoint, with an agreed payload (at minimum the `dbinstanceidentifier`, from which the
+  mechanism resolves the connector). Defining that contract is a prerequisite to building.
+
+## 4. Targets and connector mapping (verified via the Fivetran API)
+
+| RDS instance (`dbinstanceidentifier`) | Active connector | `schedule_type` | Notes |
+|------|------|------|------|
+| `mpdx-api-prod` | `loft_unabashed` (`el_mpdx`) | manual (DOT-scheduled) | dead twin `enter_incredulity` (auto, paused) exists |
+| `global-registry-flat-prod` | `freebee_tuberculosis` (`el_global_registry_flat`) | manual (DOT-scheduled) | dead twin `quicken_wow` (auto, paused) exists |
+| `global-registry-prod` | `centralized_mitigation` (`el_global_registry`) | **auto (Fivetran-native)** | needs migration to DOT (Section 8); dead twin `dawdler_managing` (auto, paused) exists |
 
 The instance-to-connector map must be a hard-coded, reviewed table in the mechanism's config
-(mirroring `connector_to_dbt_mapping`), not inferred at runtime. The metric, caps, and
-thresholds live in notebook 14785624 and are DevOps-owned — not reproduced here.
+(mirroring `connector_to_dbt_mapping`), not inferred at runtime — multiple connectors share a
+schema, and only the active one is the target.
 
-## 3. Architecture
+## 5. The DSE mechanism
 
-The mechanism follows DOT's standard push pattern (`ARCHITECTURE.md`): a thin Cloud Function
-validates the inbound trigger and publishes to Pub/Sub; a Cloud Workflow performs the
-orchestration. It reuses the existing `fivetran-trigger/fivetran_client.py` primitives.
+The mechanism follows DOT's push pattern (`ARCHITECTURE.md`): a thin Cloud Function validates
+the inbound trigger and publishes to Pub/Sub; a Cloud Workflow performs the orchestration. It
+reuses the existing `fivetran-trigger/fivetran_client.py` primitives. It does **not** poll for
+slot fullness — detection pushes the trigger in. There is no DSE-side database access to the
+RDS primaries.
 
-```
-DevOps Datadog monitor (slot at 50% of cap)  →  webhook
-  │
-  ▼
-Cloud Function  (validate the webhook secret, map instance → connector_id, publish to Pub/Sub, return 200)
-  │
-  ▼  Pub/Sub → Eventarc
-Cloud Workflow  (drain orchestration — see Section 4)
-  │
-  ▼
-Fivetran  →  sync advances restart_lsn  →  WAL released  →  slot drains
-```
-
-The mechanism does **not** poll for slot fullness — DevOps's monitor detects the threshold and
-pushes the trigger in. There is no DSE-side database access to the RDS primaries.
-
-## 4. Drain orchestration (the state machine)
+### Drain orchestration (state machine)
 
 On each trigger, the Workflow inspects connector state via `fivetran_client`
 (`determine_sync_status`, `get_connector_details`) and branches:
 
 | Connector state | Action |
 |---|---|
-| A sync is **already running** | **No-op.** A drain is already in progress; firing again would stack redundant syncs (handles both cooldown and duplicate triggers from monitor re-fire / at-least-once Pub/Sub delivery). |
-| **Paused** | **Resume** (`update_connector(paused=False)`), then force-sync. A paused connector cannot accept an API-triggered sync. |
-| **Broken** (auth / schema failure — not merely paused) | **Stop.** A force-sync will not drain a broken connector. Emit a structured failure signal and let DevOps's escalation handle continued slot growth. Do not attempt a futile sync or a repair. |
+| A sync is **already running** | **No-op.** A drain is already in progress; firing again would stack redundant syncs (handles cooldown and duplicate triggers from monitor re-fire / at-least-once Pub/Sub delivery). |
+| **Paused** | **Resume** (`update_connector(paused=False)`), then force-sync. |
+| **Broken** (auth / schema failure, not merely paused) | **Stop.** A force-sync will not drain a broken connector. Emit a structured failure signal and let DevOps's escalation handle continued growth. Do not attempt a futile sync or a repair. |
 | **Healthy** | **Force-sync** via `trigger_sync(connector_id, force=True)`. |
 
-Two properties this guarantees:
+Two required properties:
 
-- **Schedule-neutral.** The mechanism calls `trigger_sync` directly and must **not** route
-  through the existing `fivetran-trigger` Cloud Function entry point, which sets
-  `schedule_type: "manual"` on every invocation. Mutating the schedule as a side effect would
-  undermine the connectors' native scheduling (and the frequency change in Section 6). The
-  only connector mutation the mechanism performs is resuming a paused connector.
+- **Schedule-neutral.** The mechanism's only deliberate connector mutation is resuming a
+  paused connector. It must **not** set `schedule_type` as a side effect. (The existing
+  `fivetran-trigger` Cloud Function sets `schedule_type: "manual"` on every call — see
+  Section 6, which is why reusing it as-is is one of the options under review.)
 - **A forced sync is not proof of a drain.** A `200` from the force call does not guarantee
-  WAL was released — a sync already in flight, or a long historical re-sync (e.g. on
-  history-mode tables), may not advance `restart_lsn` immediately. The mechanism confirms only
-  that the sync was **accepted/initiated**; whether the slot actually fell is confirmed by
-  **DevOps's metric** (their monitor simply re-fires if it did not drain). The mechanism does
-  not re-implement metric-watching.
+  WAL was released — a sync already in flight, or a long historical re-sync, may not advance
+  `restart_lsn` immediately. The mechanism confirms only that the sync was accepted; whether
+  the slot actually fell is confirmed by DevOps's metric (their monitor re-fires if it did
+  not drain). The mechanism does not re-implement metric-watching.
 
-## 5. Drain endpoint
+### Drain endpoint
 
 `fivetran_client.trigger_sync(connector_id, force=True)` issues
 `POST /v1/connectors/{connector_id}/force` with body `{"force": true}`. The client already
-provides every primitive the mechanism needs: `trigger_sync`, `determine_sync_status`,
-`update_connector`, `get_connector_details`.
+provides `trigger_sync`, `determine_sync_status`, `update_connector`, `get_connector_details`.
 
-## 6. Coupled change: sync-frequency reduction (later, not part of the valve)
+## 6. Orchestration placement — options for review
+
+Where the drain orchestration lives is the central design decision, and the one this draft
+most wants feedback on. DOT already triggers syncs through the `fivetran-trigger` Cloud
+Function: Cloud Scheduler invokes it on a cron with a `connector_id`, and it sets
+`schedule_type: "manual"` and force-syncs. The valve is a *different trigger source*
+(event-driven from detection, not cron) and needs *guards* the scheduled path does not. Three
+options:
+
+### Option A — Valve calls the existing `fivetran-trigger` Cloud Function
+The detection webhook POSTs a `connector_id` to the same HTTP function the scheduler uses.
+- **Pros:** essentially no new code; the valve is just another caller; `manual` is already
+  correct for DOT-scheduled targets.
+- **Cons:** that function is intentionally simple — no broken/paused guard, no
+  already-syncing check, no resume/stop logic (Section 5). It force-syncs and sets `manual`
+  *unconditionally*, which is wrong for any connector not yet migrated to DOT scheduling.
+  Adding the guards means bloating the shared scheduled-trigger path.
+
+### Option B — Dedicated guarded valve component
+A thin Cloud Function (validate the trigger) → Pub/Sub → a new Cloud Workflow that runs the
+Section 5 state machine, reusing `fivetran_client`, separate from the scheduled trigger.
+- **Pros:** clean separation; implements the guards properly; the valve's *conditional*
+  semantics differ from the scheduler's *fire-and-forget*; shippable now, independent of the
+  broader scheduling migration; fits the existing webhook→Pub/Sub→Workflow pattern
+  (`fivetran-webhook` already does webhook→Pub/Sub).
+- **Cons:** a new component; two sync-trigger paths in DOT until/unless they converge.
+
+### Option C — Unified Fivetran orchestrator
+Evolve `fivetran-trigger` into one component handling scheduled *and* event-driven syncs with
+shared guards, as part of the "all connectors DOT-scheduled" direction (Section 8).
+- **Pros:** strategically coherent — addresses the valve and the scheduling migration
+  together; one home for all Fivetran sync logic with guards; the right place for "set
+  `manual` conditionally."
+- **Cons:** much larger scope; couples the (contained) valve to a broader refactor; needs the
+  most design and review time.
+
+**Open decision:** ship **B now and converge to C later** (the valve Workflow becomes a
+building block of the unified orchestrator), or commit to **C from the start**. Option A is
+viable only if the guards in Section 5 are judged unnecessary. This is the decision to settle
+in review.
+
+## 7. Coupled change: sync-frequency reduction (later)
 
 The 2026-06-16 review also agreed to reduce these connectors' scheduled sync frequency once
 the valve is in place — a sparser schedule is safe precisely because the valve catches slot
-growth between syncs. Sequence: land and prove the valve first, then relax `sync_frequency`
-(via fivetran-as-code or a connector PATCH).
+growth between syncs. Sequence: land and prove the valve first, then relax `sync_frequency`.
 
 Headroom is large, so this is low-risk: source-freshness tolerances are wide (MPDX
 `warn 1d / error 10d`; Global Registry and Global Registry Flat `warn 7d / error 14d`), the
 connectors currently sync hourly, and the downstream warehouse builds run on their own
-schedules. Downstream dbt builds are intentionally **decoupled** from Fivetran `sync_end`
-(they run on independent schedules to control BigQuery cost), so valve-triggered syncs do not
-fan out extra builds, and the `fivetran_dbt`/`sync_end` interaction (DT-511) does not apply
-here. The safe minimum sync frequency is therefore bounded by each connector's downstream
+schedules. Downstream dbt builds are intentionally decoupled from Fivetran `sync_end` (they
+run on independent schedules to control BigQuery cost), so valve-triggered syncs do not fan
+out extra builds. The safe minimum sync frequency is bounded by each connector's downstream
 build time, not by the current hourly cadence.
 
-## 7. Open items / to-dos
+## 8. Coupled cleanup: migrate connectors to DOT scheduling
 
-1. **Confirm `global-registry-prod`'s Fivetran connector.** Only `mpdx-api-prod`
-   (`loft_unabashed`) and `global-registry-flat-prod` (`freebee_tuberculosis`) are wired in
-   the DOT scheduler today; `global-registry-prod` has no connector mapped there. Locating /
-   confirming it is a cleanup to-do, not a design blocker.
-2. Decide where the orchestration lives — extend `fivetran-trigger/` (which holds the client)
-   or a dedicated Workflow — consistent with the push pattern and schedule-neutrality.
-3. Sequence the sync-frequency reduction after the valve is proven (Section 6).
+Principle: **all Fivetran connectors should be DOT-scheduled** (`schedule_type: "manual"`,
+triggered by DOT via `fivetran-trigger`) rather than Fivetran-native (`auto`). DOT scheduling
+is also what lets the valve drain a connector without fighting a native schedule.
 
-## 8. Implementation outline (DSE scope)
+A connector listed in the `fivetran_trigger` schedule block (cru-terraform
+`applications/data-warehouse/dot/prod/functions.tf`) is DOT-scheduled; the rest are
+Fivetran-native. The valve's `global-registry-prod` target (`centralized_mitigation`) is one
+such case. Audit of active `postgres_rds` connectors still on `auto` scheduling (migration
+candidates):
 
-- [ ] Hard-coded, reviewed instance → connector_id map (confirm `global-registry-prod`).
-- [ ] Cloud Function: validate the webhook secret, map instance → connector, publish to Pub/Sub.
-- [ ] Cloud Workflow drain orchestration (Section 4): state check → no-op / resume+sync / stop / force-sync; schedule-neutral; emit a structured failure signal on the broken-connector path for DevOps's alerting.
-- [ ] Confirm with DevOps the trigger contract (webhook payload + secret) their 50% monitor will send.
-- [ ] Test: drive a slot toward 50% (or simulate the trigger) → mechanism force-syncs → slot drains; verify the no-op-while-syncing, paused-resume, and broken-connector-stop branches.
-- [ ] Runbook note (DSE side): what the broken-connector failure signal means and how to act on it.
-- [ ] After the valve is proven: relax `sync_frequency` on the connectors (Section 6).
+- `centralized_mitigation` — `el_global_registry` (the valve's gr-prod target)
+- `chairmanship_bestowing` — `el_staff_accounting`
+- `committee_persisting`, `define_uncooked` — `el_ministry_managed_domains`
+- `communal_whoops`, `crossing_accidental` — `el_ert`
+- `entrench_security` — `el_summer_missions`
+- `furniture_magnanimous` — `el_staff_accounting_uat`
+- `hesitate_fret` — `el_cap`
+
+(The full principle extends to non-Postgres connectors too; the list above is the
+slot-relevant subset. Paused/dead `auto` connectors — e.g. `dawdler_managing`,
+`enter_incredulity`, `quicken_wow` — are not migration targets.)
+
+This is a separate workstream that the valve depends on for `global-registry-prod`: that
+connector must be migrated to DOT scheduling (add to the `fivetran_trigger` block, set
+`manual`) before the valve can drain it cleanly.
+
+## 9. Open items / decisions for review
+
+1. **Orchestration placement (Section 6):** B-now-converge-to-C vs. C-from-the-start. The
+   central decision.
+2. **Trigger contract (Section 3):** define the valve trigger (a 50%-of-cap monitor or a
+   webhook on an existing monitor) and the payload it sends to the mechanism.
+3. **Connector scheduling migration (Section 8):** migrate `centralized_mitigation` (and the
+   wider `auto` list) to DOT scheduling; sequence relative to the valve.
+4. **Frequency reduction (Section 7):** sequence after the valve is proven.
+
+## 10. Implementation outline (DSE scope)
+
+- [ ] Hard-coded, reviewed instance → connector_id map (Section 4).
+- [ ] Agree the trigger contract with detection (Section 3).
+- [ ] Cloud Function: validate the trigger, map instance → connector, publish to Pub/Sub.
+- [ ] Cloud Workflow: the Section 5 state machine (no-op / resume+sync / stop+signal /
+      force-sync); schedule-neutral; emit a structured failure signal on the broken path.
+- [ ] Test: drive a slot toward the trigger (or simulate it) → mechanism force-syncs → slot
+      drains; verify the already-syncing, paused-resume, and broken-stop branches.
+- [ ] Runbook note (DSE side): what the broken-connector failure signal means and how to act.
+- [ ] Migrate `global-registry-prod` (`centralized_mitigation`) to DOT scheduling (Section 8).
+- [ ] After the valve is proven: relax `sync_frequency` on the connectors (Section 7).


### PR DESCRIPTION
## What

Adds a design doc for the Data Engineering side of the Fivetran replication-slot safety valve: `docs/DESIGN_fivetran_slot_safety_valve.md`. Docs only — no code.

Tracking: **DT-561**. Related: **DT-511**. Reference: Datadog notebook 14785624 (metric, caps, thresholds).

## Why

Three production AWS RDS Postgres instances (mpdx-api-prod, global-registry-prod, global-registry-flat-prod) feed the warehouse via Fivetran logical replication. When a replication slot's retained WAL reaches its `max_slot_wal_keep_size` cap, Postgres invalidates the slot and Fivetran must do a full re-snapshot — the cause of the recurring "Invalid Replication Slot" breaks. The agreed remedy (2026-06-16 DSE/DevOps review) is a safety valve: at 50% of cap, automatically force a Fivetran sync to drain the slot before invalidation.

## Scope

This doc covers **only the DSE mechanism** — the part that runs the Fivetran sync when a slot hits 50%. DevOps owns the Datadog metric, the 50/70/100% thresholds, the monitors, and escalation, handled through their standard process (referenced, not specified here).

The mechanism follows DOT's push pattern: DevOps's monitor → webhook → thin Cloud Function → Cloud Workflow that drains via a state machine (a sync already running → no-op; paused → resume + sync; broken → stop + signal; healthy → force-sync), schedule-neutral, reusing `fivetran-trigger/fivetran_client.py`. A forced sync is not proof of a drain; the slot drop is confirmed by DevOps's metric.

## Review history

Refined through three persona reviews (DevOps, Senior Data Engineer, Architect) plus a DSE/DevOps scoping pass. Key corrections folded in: the connector mapping is partly known in `functions.tf` (`mpdx-api-prod → loft_unabashed`, `global-registry-flat-prod → freebee_tuberculosis`; `global-registry-prod`'s connector is a cleanup to-do); downstream dbt builds are intentionally decoupled from `sync_end` for BigQuery cost, so valve syncs do not fan out builds and DT-511 does not apply; the drain endpoint is `POST connectors/{id}/force`; and the mechanism must be schedule-neutral (not route through the existing `fivetran-trigger` Cloud Function, which sets `schedule_type: "manual"`).

## Status

Draft design for cross-team (DSE + DevOps) review. Open items: confirm the `global-registry-prod` connector, choose the orchestration home, and sequence the coupled sync-frequency reduction after the valve is proven.
