### PR TITLE
Add dbt-classify deploy workflow + document the per-function deploy convention (DT-568)

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-dbt-classify.yml
+++ b/.github/workflows/build-deploy-cloudrun-dbt-classify.yml
@@ -1,0 +1,28 @@
+name: Build & Deploy DBT Classify
+
+on:
+  push:
+    branches:
+      - main
+      - poc
+      - staging
+    paths:
+      - 'dbt-classify/**'
+  workflow_dispatch:
+
+jobs:
+  build_and_deploy_dbt_classify:
+    uses: CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@v1
+    with:
+      function_name: dbt-classify
+      entry_point: classify_run
+      runtime: python312
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+    secrets:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}
+      WORKLOAD_IDENTITY_POOL: ${{ vars.WORKLOAD_IDENTITY_POOL }}
+      WORKLOAD_IDENTITY_PROVIDER: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GCP_SERVICE_ACCOUNT_EMAIL: ${{ vars.GCP_SERVICE_ACCOUNT_EMAIL }}
+      GCP_REGION: ${{ vars.GCP_REGION }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,40 @@ Deployment uses two repos:
 If GHA fails with "trigger required", it means Terraform hasn't been applied yet for that
 function in the target environment. The function must exist in GCP before GHA can update it.
 
+### Phase 2 is per-function — each function needs its OWN deploy workflow
+
+GitHub Actions does NOT deploy functions generically. Each function deploys via a dedicated
+workflow file: `.github/workflows/build-deploy-cloudrun-<function-name>.yml`. It is path-filtered
+to `<function-name>/**`, so merging to `main` (prod) / `staging` (stage) / `poc` redeploys only
+the functions whose source changed; it also exposes `workflow_dispatch` for a manual run.
+
+**If you add a new function and forget this file, the code NEVER deploys** — merging to `main`
+runs only the test suite, the function keeps serving the Terraform placeholder, and nothing errors
+or warns. (This is exactly how `dbt-classify` reached `main` un-deployed.)
+
+Each workflow is a thin caller of the shared reusable workflow
+`CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@v1`. Copy an existing one
+(e.g. `build-deploy-cloudrun-dbt-trigger.yml`) and change `name`, `function_name`, `entry_point`
+(the `@functions_framework.http` function in `main.py`), `runtime`, and the `paths:` filter.
+
+That reusable workflow deploys **source-only**: `gcloud functions deploy --source --entry-point
+--runtime --build-service-account`. It does NOT pass `--set-secrets`, `--run-service-account`,
+`--timeout`, or `--memory`, so on an existing gen2 function that is a partial update and the
+Terraform-set secret bindings, runtime SA, timeout, and memory are PRESERVED across deploys. Set
+those in Terraform (phase 1), never here.
+
+### Checklist: adding a new Cloud Function
+
+1. `<function-name>/` folder — `main.py` (with an `@functions_framework.http` entry point),
+   `requirements.txt`, `requirements-test.txt`, and tests.
+2. Terraform module in cru-terraform `functions.tf` (+ secrets, SA, IAM, and any workflow/eventarc
+   wiring), applied FIRST. The Terraform `name` MUST equal the folder name.
+3. **`.github/workflows/build-deploy-cloudrun-<function-name>.yml`** — copy a sibling and set
+   `name`, `function_name`, `entry_point`, `runtime`, and the `paths:` filter. Without this the
+   function never deploys.
+4. Add the function to the `## Functions` table below.
+5. Populate any secret values (see README "Secrets").
+
 ## Architecture
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the push-not-poll pattern, workflow diagrams, and anti-patterns.
@@ -39,6 +73,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the push-not-poll pattern, 
 
 | Directory | Purpose |
 |-----------|---------|
+| `dbt-classify/` | Classifies a failed dbt Cloud run as transient (retryable) or not, for the dbt-retry-workflow. Reads run metadata + `run_results.json` (kept out of the Cloud Workflow, which can't hold the large artifact in a variable). |
 | `dbt-trigger/` | Triggers dbt Cloud jobs via API. Accepts optional `cause` for tracking. |
 | `dbt-webhook/` | Receives dbt Cloud webhooks. Routes success → Fabric, failure → retry. |
 | `fivetran-trigger/` | Triggers Fivetran sync jobs |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ various pieces of our ELT stack.
 Each function has its own folder.
 The folder name exactly matches the 'name' component of several kinds of GCP resources,
 but most importantly it matches the GCR function name.
+Each function also has its own deploy workflow at
+`.github/workflows/build-deploy-cloudrun-<folder>.yml` (see "Automated deploys" below) — a new
+function does not deploy until that file exists.
 
 ## Local setup
 
@@ -53,6 +56,28 @@ After Terraform creates the secret, add the value via the GCP Console or CLI:
 Devs in the `dps-gcp-role-data-engineers@cru.org` group have access to write secret values but not read them (except in POC).
 
 **Important:** Creating a new secret version does not automatically take effect. You'll need to trigger a new deployment (push to `main` for prod, `staging` for stage).
+
+## Automated deploys (prod & stage)
+
+Prod and stage deploy automatically via GitHub Actions — there is nothing to run by hand:
+
+- Merge/push to `main` → deploys to **prod** (`cru-data-orchestration-prod`).
+- Push to `staging` → deploys to **stage**.
+
+Each function has its **own** deploy workflow: `.github/workflows/build-deploy-cloudrun-<function-name>.yml`,
+path-filtered to `<function-name>/**` so merging only redeploys the functions whose source changed
+(plus a manual `workflow_dispatch` trigger). Each is a thin caller of the shared reusable workflow
+`CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@v1`.
+
+**Adding a new function?** You MUST add its `build-deploy-cloudrun-<name>.yml` — copy an existing one
+and change `name`, `function_name`, `entry_point`, `runtime`, and the `paths:` filter. Without it,
+merging to `main` runs only the tests; the function never deploys and silently keeps serving the
+Terraform placeholder, with no error to tell you.
+
+The reusable workflow deploys source-only (`gcloud functions deploy --source --entry-point --runtime
+--build-service-account`) — it does not pass `--set-secrets`, `--run-service-account`, `--timeout`, or
+`--memory`, so the Terraform-managed runtime config (secrets, SA, timeout, memory) is preserved across
+deploys. Configure those in Terraform (see the cru-terraform `dot` modules), not here.
 
 ## Deploy new code manually:
 You probably should only be doing this in the POC env.


### PR DESCRIPTION
## Why

`dbt-classify` (#106) merged to `main` but **never deployed**. dot deploys each Cloud Function via a dedicated GitHub Actions workflow (`build-deploy-cloudrun-<fn>.yml`, path-filtered to `<fn>/**`), and `dbt-classify`'s workflow was missing. So the #106 merge ran only the test suite — nothing pushed the code. The function still serves the terraform placeholder (revision `00001`, `entryPoint: "placeholder"`), and the dbt auto-retry pipeline declines every failure (`not_retryable`, `reason=unknown`) instead of retrying the transient ones.

This adds the missing deploy workflow and documents the convention so a new function can't silently fail to deploy again.

## Changes

- **`.github/workflows/build-deploy-cloudrun-dbt-classify.yml`** — a 1:1 mirror of `build-deploy-cloudrun-dbt-trigger.yml`, differing only in the `dbt-classify` values (`function_name: dbt-classify`, `entry_point: classify_run`, `runtime: python312`, `paths: dbt-classify/**`) plus `workflow_dispatch`.
- **`CLAUDE.md`** — new "Phase 2 is per-function — each function needs its OWN deploy workflow" subsection + an "adding a new Cloud Function" checklist; `dbt-classify` added to the Functions table.
- **`README.md`** — new "Automated deploys (prod & stage)" section + an Organization note that a function doesn't deploy until its workflow file exists.

## Why this is safe (verified, not assumed)

The reusable workflow (`CruGlobal/.github/.github/workflows/build-deploy-cloudrun-function.yml@v1`) deploys **source-only**: `gcloud functions deploy --source --entry-point --runtime --build-service-account`, with no `--set-secrets`, `--run-service-account`, `--timeout`, or `--memory`. On an existing gen2 function that is a partial update — unspecified flags are left unchanged. Confirmed empirically against the live siblings that use the identical workflow:

| Function | Revision | Runtime SA | Timeout | Secret still bound |
|---|---|---|---|---|
| `dbt-trigger` | 00005 | `dbt-trigger-sa@…` | 60 | `dbt-trigger_DBT_TOKEN` ✅ |
| `dbt-webhook` | 00017 | `dbt-webhook-sa@…` | 60 | `dbt-webhook_DBT_WEBHOOK_SECRET` ✅ |

After 5 and 17 source-only deploys, both still hold their terraform-bound secret and their terraform runtime SA. So deploying `dbt-classify` will set `entryPoint=classify_run` while preserving its bound `dbt-classify_DBT_TOKEN`, the `dbt-classify-sa@` runtime SA, the 300s timeout, and 512Mi memory.

## Deploy after merge

This PR touches `.github/`, not `dbt-classify/**`, so the path filter won't auto-fire on merge. Deploy manually once merged:

```
gh workflow run build-deploy-cloudrun-dbt-classify.yml --ref main
```

Then verify: the function's revision advances past `00001` and `entryPoint` becomes `classify_run`, and a real/synthetic transient failure classifies as retryable (the retry workflow triggers a re-run with an "Auto-retry…" cause).

## Test Plan

- [x] Deploy workflow is a verified 1:1 mirror of the sibling pattern (only the intended `dbt-classify` values differ)
- [x] `function_name` matches the terraform-created function name exactly (`dbt-classify`)
- [x] `entry_point: classify_run` matches the `@functions_framework.http` handler in `dbt-classify/main.py`
- [x] Source-only deploy preserves terraform-set secret/SA/timeout (verified against live siblings)
- [ ] Post-merge: dispatch the workflow and confirm the function serves the real classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
