### PR TITLE
Stop US Donations Fabric copy job (remove dbt job 163545 mapping)

### DIFF
--- a/dbt-webhook/main_test.py
+++ b/dbt-webhook/main_test.py
@@ -155,17 +155,30 @@ def test_success_any_job_id_publishes(mock_publisher):
 
 # ---------------------------------------------------------------------------
 # Legacy Fabric dual-publish
+#
+# The real webhook_utils.map_dbt_to_fabric mapping is intentionally empty (no
+# job currently triggers a Fabric job). These tests patch map_dbt_to_fabric to
+# inject a mapped job so the dual-publish path stays covered for future entries.
 # ---------------------------------------------------------------------------
 
+FABRIC_MAPPING = {
+    "workspace_id": "test-workspace",
+    "item_id": "test-item",
+    "refresh_workspace_id": "test-refresh-workspace",
+    "lakehouse_dataset_id": "test-lakehouse-dataset",
+    "job_type": "Execute",
+}
 
+
+@mock.patch.object(main, "map_dbt_to_fabric", return_value=FABRIC_MAPPING)
 @mock.patch.object(main, "publisher")
-def test_success_with_fabric_mapping_publishes_to_both_topics(mock_publisher):
+def test_success_with_fabric_mapping_publishes_to_both_topics(mock_publisher, _mock_map):
     """Job with Fabric mapping publishes to BOTH completed and fabric topics."""
     mock_future = mock.Mock()
     mock_future.result.return_value = "msg-123"
     mock_publisher.publish.return_value = mock_future
 
-    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="163545")
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="99001")
     request = make_mock_request(payload)
 
     response = main.webhook_handler(request)
@@ -178,8 +191,9 @@ def test_success_with_fabric_mapping_publishes_to_both_topics(mock_publisher):
     assert any("fabric-job-events" in t for t in call_topics)
 
 
+@mock.patch.object(main, "map_dbt_to_fabric", return_value=FABRIC_MAPPING)
 @mock.patch.object(main, "publisher")
-def test_fabric_publish_failure_is_non_fatal(mock_publisher):
+def test_fabric_publish_failure_is_non_fatal(mock_publisher, _mock_map):
     """Fabric publish failure does not affect the 200 response or cause retry."""
     call_count = 0
 
@@ -195,7 +209,7 @@ def test_fabric_publish_failure_is_non_fatal(mock_publisher):
 
     mock_publisher.publish.side_effect = publish_side_effect
 
-    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="163545")
+    payload = make_dbt_webhook_payload(status="Success", status_code=10, job_id="99001")
     request = make_mock_request(payload)
 
     response = main.webhook_handler(request)

--- a/dbt-webhook/webhook_utils.py
+++ b/dbt-webhook/webhook_utils.py
@@ -112,15 +112,17 @@ def map_dbt_to_fabric(dbt_job_id: str) -> dict:
     This mapping will be removed when the Fabric workflow subscribes to the
     dbt-job-completed topic with a Pub/Sub attribute filter instead.
     """
-    dbt_to_fabric_mapping = {
-        "163545": {
-            "workspace_id": "c2bafcfd-df3d-4383-8f76-aed296260453",
-            "item_id": "457998b0-be0c-437c-9b1a-4e5f17b3bf77",
-            "refresh_workspace_id": "b3d68b22-ae01-4017-af31-1392c5c54a6c",
-            "lakehouse_dataset_id": "1402b359-a8e4-48f2-a69e-50bff4e37122",
-            "job_type": "Execute",
-        }
-    }
+    # Map dbt job IDs to their Fabric job config. Empty = no job currently
+    # triggers a Fabric job from this webhook. To (re)enable one, add an entry:
+    #   "<dbt_job_id>": {
+    #       "workspace_id": "...",
+    #       "item_id": "...",
+    #       "refresh_workspace_id": "...",
+    #       "lakehouse_dataset_id": "...",
+    #       "job_type": "Execute",
+    #   }
+    # (163545 "US Donations" → us_donations_prod CopyJob was removed 2026-07-01.)
+    dbt_to_fabric_mapping = {}
 
     mapping = dbt_to_fabric_mapping.get(dbt_job_id)
     if not mapping:


### PR DESCRIPTION
## What
Removes the dbt job **163545** ("US Donations" → `us_donations_prod`) entry from `map_dbt_to_fabric` in `dbt-webhook`, so the webhook no longer triggers the Fabric **CopyJob** (item `457998b0…`) after that dbt job completes.

## Why
The Fabric copy job has been running **daily (~06:30 UTC)**, driven by:

```
dbt job 163545 succeeds → dbt Cloud webhook → dbt-webhook
  → publishes to fabric-job-events → fabric-job-workflow → Fabric copy job
```

We want to stop this specific job.

## Approach
- Only the `163545` mapping entry is removed (`dbt_to_fabric_mapping = {}`).
- The **dual-publish structure is intentionally kept** (`map_dbt_to_fabric`, `create_fabric_job_message`, `fabric_topic_path`, and the legacy publish block) so other dbt jobs can trigger Fabric jobs later by adding a mapping entry.
- All other routing is unchanged: success → `dbt-job-completed`, failure → `dbt-retry-events`.

## Tests
- The two dual-publish tests now patch `map_dbt_to_fabric` with a dummy mapping so that path stays covered.
- `pytest` — **15 passed**.

## Deploy note
Merging to `main` redeploys the `dbt-webhook` function to prod via `.github/workflows/build-deploy-cloudrun-dbt-webhook.yml`, which takes effect on the next dbt 163545 completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)