### PR TITLE
DT-594: woo-sync loader fails loud on unresolved watermark

### DIFF
--- a/woo-sync/conftest.py
+++ b/woo-sync/conftest.py
@@ -1,0 +1,29 @@
+"""
+Pytest configuration for woo-sync tests.
+
+main.py instantiates a module-level BigQueryClient, which calls
+google.auth.default() at import time and needs GCP credentials. Patch it before
+main.py is imported so tests run locally / in CI without credentials (mirrors the
+dbt-webhook conftest pattern).
+"""
+import sys
+from unittest import mock
+
+from google.auth.credentials import AnonymousCredentials
+
+with mock.patch.dict(
+    "os.environ",
+    {
+        "GOOGLE_CLOUD_PROJECT": "test-project",
+        "BIGQUERY_PROJECT_NAME": "test-project",
+        "BIGQUERY_DATASET_NAME": "test_dataset",
+    },
+):
+    with mock.patch(
+        "google.auth.default",
+        return_value=(AnonymousCredentials(), "test-project"),
+    ):
+        # Clear any cached module so it re-imports under the mocked credentials.
+        if "main" in sys.modules:
+            del sys.modules["main"]
+        import main  # noqa: F401

--- a/woo-sync/main.py
+++ b/woo-sync/main.py
@@ -156,27 +156,44 @@ def load_to_dataframe(
         logger.exception(f"Error occurred: {e}")
         raise
 
-def get_last_load_date_time(obj):
+def get_last_load_date_time(query, client=None):
     """
-    This function gets the latest sync_timestamp value from the specified table
+    Return the latest sync_timestamp for a store's orders as an ISO-8601 string,
+    used as the WooCommerce ``modified_after`` incremental watermark.
+
+    Fails loud (DT-594): if the watermark cannot be resolved -- a query error, or a
+    query that returns 0 rows -- this raises instead of returning ``None``. A
+    ``None`` watermark makes the caller request ``modified_after=None``, which pulls
+    the full order history (~1800 pages), hangs past the Cloud Run timeout, and
+    wedges the downstream dbt job with no self-healing. Raising lets
+    ``trigger_sync``'s handler exit non-zero so the failure is visible and the next
+    run retries cleanly.
+
+    NOTE: a legitimately empty store (first-ever load) also returns 0 rows here and
+    will raise. A deliberate initial-backfill path is a separate follow-up decision.
+
+    ``client`` is injectable so the watermark query can be unit-tested without GCP.
     """
     setup_logging()
-    query = obj
-    client = bigquery.Client(project=google_cloud_project_id)
+    if client is None:
+        client = bigquery.Client(project=google_cloud_project_id)
 
     try:
         query_job = client.query(query)
-        result = query_job.result()
-        row = list(result)[0]
-        last_update = row.sync_timestamp
-        last_update = datetime.fromisoformat(str(last_update)).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
+        rows = list(query_job.result())
+    except Exception as e:
+        logger.exception(f"Watermark query failed: {str(e)}")
+        raise
+
+    if not rows:
+        raise ValueError(
+            "Watermark query returned 0 rows; cannot resolve the incremental "
+            "modified_after watermark. Aborting rather than pulling all order "
+            "history (DT-594)."
         )
 
-        return last_update
-
-    except Exception as e:
-        logger.info(f"Get last load date error: {str(e)}")
+    last_update = rows[0].sync_timestamp
+    return datetime.fromisoformat(str(last_update)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 ## BQ DATAFRAMES -------------------------------------------------------------------------------------------------------------------------------------------
 def process_orders(list):
@@ -1135,6 +1152,11 @@ def get_orders_and_items(env_var_list):
     """
     setup_logging()
     last_update_date_time = env_var_list["order_last_update_date_time"]
+    if not last_update_date_time:
+        raise ValueError(
+            "order_last_update_date_time is empty; refusing to request "
+            "modified_after=None, which would pull the full order history (DT-594)."
+        )
     logger.info(last_update_date_time)
     url = env_var_list["orders_api_url"]
     
@@ -1155,14 +1177,12 @@ def get_orders_and_items(env_var_list):
         logger.info(str(current_page) + ' of ' + str(total_pages))
         params = {"modified_after": last_update_date_time, "per_page": 100, "page": current_page}
         response = requests.get(url, headers=headers, params=params, timeout=60)
-        if response.status_code != 200:
-            logger.error(f"API Error: {str(response.status_code)}")
-        else:
-            total_pages = int(response.headers.get('X-WP-TotalPages', '1'))
-            order_resp = response.json()
-            for o in order_resp:
-                orders(o, order_list, env_var_list)
-                order_items(o, order_item_list, env_var_list)
+        response.raise_for_status()
+        total_pages = int(response.headers.get('X-WP-TotalPages', '1'))
+        order_resp = response.json()
+        for o in order_resp:
+            orders(o, order_list, env_var_list)
+            order_items(o, order_item_list, env_var_list)
         current_page += 1
 
     process_orders(order_list)
@@ -1196,16 +1216,14 @@ def get_products_and_bundles(env_var_list):
         logger.info(str(current_page) + ' of ' + str(total_pages))
         params = {"per_page": 100, "page": current_page}
         response = requests.get(url, headers=headers, params=params, timeout=60)
-        if response.status_code != 200:
-            logger.error(f"API Error: {str(response.status_code)}")
-        else:
-            total_pages = int(response.headers.get('X-WP-TotalPages', '1'))
-            product_resp = response.json()
-            for p in product_resp:
-                products(p, product_list, env_var_list)
-                product_bundles(p, product_bundle_list, env_var_list)
-                product_categories(p, product_category_list, env_var_list)
-                product_attributes(p, product_attribute_list, env_var_list)
+        response.raise_for_status()
+        total_pages = int(response.headers.get('X-WP-TotalPages', '1'))
+        product_resp = response.json()
+        for p in product_resp:
+            products(p, product_list, env_var_list)
+            product_bundles(p, product_bundle_list, env_var_list)
+            product_categories(p, product_category_list, env_var_list)
+            product_attributes(p, product_attribute_list, env_var_list)
         current_page += 1
         
     process_products(product_list)
@@ -1243,14 +1261,12 @@ def get_refunds_and_items(env_var_list):
         logger.info(str(current_page) + ' of ' + str(total_pages))
         params = {"per_page": 100, "page": current_page}
         response = requests.get(url, headers=headers, params=params, timeout=60)
-        if response.status_code != 200:
-            logger.error(f"API Error: {str(response.status_code)}")
-        else:
-            total_pages = int(response.headers.get('X-WP-TotalPages', '1'))
-            refund_resp = response.json()
-            for r in refund_resp:
-                refunds(r, refund_list, env_var_list)
-                refund_items(r, refund_item_list, env_var_list)
+        response.raise_for_status()
+        total_pages = int(response.headers.get('X-WP-TotalPages', '1'))
+        refund_resp = response.json()
+        for r in refund_resp:
+            refunds(r, refund_list, env_var_list)
+            refund_items(r, refund_item_list, env_var_list)
         current_page += 1
     
     process_refunds(refund_list)

--- a/woo-sync/main_test.py
+++ b/woo-sync/main_test.py
@@ -1,0 +1,100 @@
+import logging
+import sys
+from unittest import mock
+
+import pytest
+import requests
+import responses
+
+from main import (
+    CloudLoggingFormatter,
+    get_last_load_date_time,
+    get_orders_and_items,
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_logging():
+    """Configure the primary logger the same way main.py does, for tests."""
+    logger = logging.getLogger("primary_logger")
+    logger.handlers = []
+    logger.propagate = True
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(CloudLoggingFormatter(fmt="%(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    yield
+
+    logger.handlers = []
+    logger.propagate = False
+
+
+class _Row:
+    """Stand-in for a BigQuery result row with a sync_timestamp attribute."""
+
+    def __init__(self, sync_timestamp):
+        self.sync_timestamp = sync_timestamp
+
+
+def _mock_bq_client(rows=None, query_error=None):
+    """Build a mock BigQuery client whose query().result() yields ``rows``."""
+    client = mock.MagicMock()
+    if query_error is not None:
+        client.query.side_effect = query_error
+    else:
+        job = mock.MagicMock()
+        job.result.return_value = rows or []
+        client.query.return_value = job
+    return client
+
+
+def _orders_env(url="http://woo.test/orders", watermark="2026-07-08T13:46:01Z"):
+    return {
+        "order_last_update_date_time": watermark,
+        "orders_api_url": url,
+        "woo_api_client_id": "test-id",
+        "woo_api_client_secret": "test-secret",
+        "store_wid": "1",
+        "rls_value": "cru_woo",
+        "sync_timestamp": "2026-07-08 13:46:01+00:00",
+    }
+
+
+# --- get_last_load_date_time: fail-loud watermark (DT-594) --------------------
+
+def test_watermark_happy_path_returns_iso_string():
+    client = _mock_bq_client(rows=[_Row("2026-07-08 13:46:01")])
+    result = get_last_load_date_time("SELECT 1", client=client)
+    assert result == "2026-07-08T13:46:01Z"
+
+
+def test_watermark_zero_rows_raises_instead_of_returning_none():
+    """The core DT-594 fix: 0 rows must raise, never fall through to None."""
+    client = _mock_bq_client(rows=[])
+    with pytest.raises(ValueError, match="0 rows"):
+        get_last_load_date_time("SELECT 1", client=client)
+
+
+def test_watermark_query_error_propagates():
+    client = _mock_bq_client(query_error=RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        get_last_load_date_time("SELECT 1", client=client)
+
+
+# --- get_orders_and_items: guards + fail-loud HTTP ---------------------------
+
+def test_orders_empty_watermark_refuses_full_pull():
+    """Defense-in-depth: an empty watermark must not reach the API as None."""
+    with pytest.raises(ValueError, match="modified_after"):
+        get_orders_and_items(_orders_env(watermark=""))
+
+
+@responses.activate
+def test_orders_non_200_raises():
+    """A non-200 from the Woo API must fail loud, not silently skip the page."""
+    url = "http://woo.test/orders"
+    responses.add(responses.GET, url, status=500)
+    with pytest.raises(requests.exceptions.HTTPError):
+        get_orders_and_items(_orders_env(url=url))

--- a/woo-sync/requirements-test.txt
+++ b/woo-sync/requirements-test.txt
@@ -1,3 +1,4 @@
-pytest>=7.0.0
-pytest-mock>=3.0.0
-unittest-mock>=1.0.0
+pytest==8.2.0
+pytest-mock==3.14.0
+requests==2.33.0
+responses==0.23.1


### PR DESCRIPTION
## What & why

[DT-594](https://jira.cru.org/browse/DT-594). Hardens the woo-sync loader so it **fails loud** instead of silently pulling all history when the incremental watermark can't be resolved — the outermost defense layer against the class of failure that wedged the WooCommerce dbt pipeline (job 84393) for 5 days.

**Incident chain this closes:** a 0-row watermark read → `get_last_load_date_time` returned `None` → `modified_after=None` → ~1800-page full pull → 900s Cloud Run timeout → completion pub/sub never fired → dbt 84393 never ran → no self-heal.

> Defense-in-depth, **not demo-blocking**. The specific 2026-07-07 incident path is already closed two other ways (the `woo-sync-sa` grandfather, cru-terraform #11198 live; and DT-593 in the dgt repo). This hardens against *any* future 0-row-watermark cause.

## Changes
- **`get_last_load_date_time`** raises on 0 rows **and** on query error (`logger.exception` + `raise`), never returns `None`; client is now injectable for unit tests.
- **`get_orders_and_items`** guards an empty watermark (won't send `modified_after=None`).
- **All three API loops** (orders / products / refunds) now `response.raise_for_status()` instead of logging a non-200 and silently continuing (a second instance of the same silent-data-loss class).
- Style matched to the `process-geography` sibling (woo-sync's architectural twin).

## Tests
- First tests for woo-sync (`main_test.py` was empty — which also blocked CI, since an empty test file makes `pytest` exit 5).
- `conftest.py` patches auth before import (`AnonymousCredentials`, mirrors the dbt-webhook conftest).
- 5 tests: watermark happy / 0-row-raise / query-error, empty-watermark guard, non-200-raise (via `responses`). **All pass locally.**
- Dropped the un-installable `unittest-mock` dep; aligned `requirements-test.txt` to the house `pytest/pytest-mock/requests/responses` set.

## Decisions baked in
- **Empty/first-load:** keep the raise (no auto-backfill — would re-introduce the silent full-pull). A deliberate per-run backfill flag is a future follow-up; the docstring marks where it plugs in.
- **Runaway pull:** handled by raising the Cloud Run **Job** timeout in cru-terraform (separate change, tracked in caseload), **not** a functional page cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)