### PR TITLE
DT-561 Phase 1: add summer_missions, staff_accounting, ert-stage to the slot-valve instance map

### DIFF
--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -68,11 +68,17 @@ consequences for this design:
 |------|------|------|------|
 | `mpdx-api-prod` | `loft_unabashed` (`el_mpdx`) | manual (DOT-scheduled) | dead twin `enter_incredulity` (auto, paused) exists |
 | `global-registry-flat-prod` | `freebee_tuberculosis` (`el_global_registry_flat`) | manual (DOT-scheduled) | dead twin `quicken_wow` (auto, paused) exists |
-| `global-registry-prod` | `centralized_mitigation` (`el_global_registry`) | **auto (Fivetran-native)** | needs migration to DOT (Section 8); dead twin `dawdler_managing` (auto, paused) exists |
+| `global-registry-prod` | `centralized_mitigation` (`el_global_registry`) | manual (DOT-scheduled) | flipped auto→manual 2026-07-22 (DT-561 GR rollout); dead twin `dawdler_managing` (auto, paused) exists |
+| `summer-missions-prod` | `entrench_security` (`el_summer_missions`) | auto → manual (DOT-scheduled) | DT-561 Phase 1 (cru-terraform #11479); flips to manual on apply; dead twin `attempted_maybe` (broken 2024) |
+| `staff-accounting-app-prod` | `chairmanship_bestowing` (`el_staff_accounting`) | auto → manual (DOT-scheduled) | DT-561 Phase 1 (#11479); direct-to-BigQuery, no dbt trigger |
+| `ert-stage` | `communal_whoops` (`el_ert`) | auto → manual (DOT-scheduled) | DT-561 Phase 1 (#11479); STAGE instance; former connector `taxing_lumpish` was deleted |
 
 The instance-to-connector map must be a hard-coded, reviewed table in the mechanism's config
 (mirroring `connector_to_dbt_mapping`), not inferred at runtime — multiple connectors share a
 schema, and only the active one is the target.
+
+(Table expanded 2026-07-30 for DT-561 Phase 1: +`summer-missions-prod`, +`staff-accounting-app-prod`,
++`ert-stage`. Sections 1 and 3 describe the original three-instance pilot.)
 
 ## 5. The DSE mechanism
 
@@ -197,25 +203,24 @@ is also what lets the valve drain a connector without fighting a native schedule
 
 A connector listed in the `fivetran_trigger` schedule block (cru-terraform
 `applications/data-warehouse/dot/prod/functions.tf`) is DOT-scheduled; the rest are
-Fivetran-native. The valve's `global-registry-prod` target (`centralized_mitigation`) is one
-such case. Audit of active `postgres_rds` connectors still on `auto` scheduling (migration
-candidates):
+Fivetran-native. Audit of active `postgres_rds` connectors and their DOT-migration status:
 
-- `centralized_mitigation` — `el_global_registry` (the valve's gr-prod target)
-- `chairmanship_bestowing` — `el_staff_accounting`
-- `committee_persisting`, `define_uncooked` — `el_ministry_managed_domains`
-- `communal_whoops`, `crossing_accidental` — `el_ert`
-- `entrench_security` — `el_summer_missions`
-- `furniture_magnanimous` — `el_staff_accounting_uat`
-- `hesitate_fret` — `el_cap`
+- `centralized_mitigation` — `el_global_registry` — **migrated 2026-07-22** (DT-561 GR rollout)
+- `chairmanship_bestowing` — `el_staff_accounting` — **migrating** (DT-561 Phase 1, cru-terraform #11479)
+- `entrench_security` — `el_summer_missions` — **migrating** (DT-561 Phase 1, #11479)
+- `communal_whoops` — `el_ert` (stage) — **migrating** (DT-561 Phase 1, #11479)
+- `committee_persisting`, `define_uncooked` — `el_ministry_managed_domains` — pending (later phase)
+- `crossing_accidental` — `el_ert` (prod) — pending (later phase)
+- `furniture_magnanimous` — `el_staff_accounting_uat` — pending
+- `hesitate_fret` — `el_cap` — pending (later phase)
 
 (The full principle extends to non-Postgres connectors too; the list above is the
 slot-relevant subset. Paused/dead `auto` connectors — e.g. `dawdler_managing`,
 `enter_incredulity`, `quicken_wow` — are not migration targets.)
 
-This is a separate workstream that the valve depends on for `global-registry-prod`: that
-connector must be migrated to DOT scheduling (add to the `fivetran_trigger` block, set
-`manual`) before the valve can drain it cleanly.
+This is a separate workstream. `global-registry-prod` (`centralized_mitigation`) — which the
+valve depended on — was migrated to DOT scheduling on 2026-07-22; the remaining `auto` connectors
+above migrate connector-by-connector as each is onboarded to the valve (DT-561 rollout phases).
 
 ## 9. Decisions (resolved in review, 2026-06-18)
 
@@ -242,7 +247,8 @@ Remaining work is the implementation outline below (Section 10).
 - [ ] Test: drive a slot toward the trigger (or simulate it) → mechanism force-syncs → slot
       drains; verify the already-syncing, paused-resume, and broken-stop branches.
 - [ ] Runbook note (DSE side): what the broken-connector failure signal means and how to act.
-- [ ] Migrate the Fivetran-native (`auto`) connectors to DOT scheduling **in bulk** (Section 8),
-      including the valve's `centralized_mitigation` (`global-registry-prod`).
+- [~] Migrate the Fivetran-native (`auto`) connectors to DOT scheduling (Section 8) — the valve's
+      `centralized_mitigation` (`global-registry-prod`) migrated 2026-07-22; the rest migrate
+      per-connector as each is onboarded (DT-561 phases), in progress.
 - [ ] After the valve is proven: reduce `sync_frequency` to **daily**, each connector's run
       placed **outside its high-churn window** (Section 7).

--- a/docs/DESIGN_fivetran_slot_safety_valve.md
+++ b/docs/DESIGN_fivetran_slot_safety_valve.md
@@ -68,17 +68,17 @@ consequences for this design:
 |------|------|------|------|
 | `mpdx-api-prod` | `loft_unabashed` (`el_mpdx`) | manual (DOT-scheduled) | dead twin `enter_incredulity` (auto, paused) exists |
 | `global-registry-flat-prod` | `freebee_tuberculosis` (`el_global_registry_flat`) | manual (DOT-scheduled) | dead twin `quicken_wow` (auto, paused) exists |
-| `global-registry-prod` | `centralized_mitigation` (`el_global_registry`) | manual (DOT-scheduled) | flipped auto→manual 2026-07-22 (DT-561 GR rollout); dead twin `dawdler_managing` (auto, paused) exists |
-| `summer-missions-prod` | `entrench_security` (`el_summer_missions`) | auto → manual (DOT-scheduled) | DT-561 Phase 1 (cru-terraform #11479); flips to manual on apply; dead twin `attempted_maybe` (broken 2024) |
-| `staff-accounting-app-prod` | `chairmanship_bestowing` (`el_staff_accounting`) | auto → manual (DOT-scheduled) | DT-561 Phase 1 (#11479); direct-to-BigQuery, no dbt trigger |
-| `ert-stage` | `communal_whoops` (`el_ert`) | auto → manual (DOT-scheduled) | DT-561 Phase 1 (#11479); STAGE instance; former connector `taxing_lumpish` was deleted |
+| `global-registry-prod` | `centralized_mitigation` (`el_global_registry`) | manual (DOT-scheduled) | dead twin `dawdler_managing` (auto, paused) exists |
+| `summer-missions-prod` | `entrench_security` (`el_summer_missions`) | auto → manual (DOT-scheduled) | onboarding (DT-561 Phase 1); dead twin `attempted_maybe` (auto, broken) exists |
+| `staff-accounting-app-prod` | `chairmanship_bestowing` (`el_staff_accounting`) | auto → manual (DOT-scheduled) | onboarding (DT-561 Phase 1); direct-to-BigQuery, no dbt trigger |
+| `ert-stage` | `communal_whoops` (`el_ert`) | auto → manual (DOT-scheduled) | onboarding (DT-561 Phase 1); STAGE instance |
 
 The instance-to-connector map must be a hard-coded, reviewed table in the mechanism's config
 (mirroring `connector_to_dbt_mapping`), not inferred at runtime — multiple connectors share a
 schema, and only the active one is the target.
 
-(Table expanded 2026-07-30 for DT-561 Phase 1: +`summer-missions-prod`, +`staff-accounting-app-prod`,
-+`ert-stage`. Sections 1 and 3 describe the original three-instance pilot.)
+(Sections 1 and 3 describe the original three-instance pilot; the table above is the current full
+set, expanded under DT-561 Phase 1.)
 
 ## 5. The DSE mechanism
 
@@ -205,10 +205,10 @@ A connector listed in the `fivetran_trigger` schedule block (cru-terraform
 `applications/data-warehouse/dot/prod/functions.tf`) is DOT-scheduled; the rest are
 Fivetran-native. Audit of active `postgres_rds` connectors and their DOT-migration status:
 
-- `centralized_mitigation` — `el_global_registry` — **migrated 2026-07-22** (DT-561 GR rollout)
-- `chairmanship_bestowing` — `el_staff_accounting` — **migrating** (DT-561 Phase 1, cru-terraform #11479)
-- `entrench_security` — `el_summer_missions` — **migrating** (DT-561 Phase 1, #11479)
-- `communal_whoops` — `el_ert` (stage) — **migrating** (DT-561 Phase 1, #11479)
+- `centralized_mitigation` — `el_global_registry` — **DOT-scheduled**
+- `chairmanship_bestowing` — `el_staff_accounting` — **onboarding** (DT-561 Phase 1)
+- `entrench_security` — `el_summer_missions` — **onboarding** (DT-561 Phase 1)
+- `communal_whoops` — `el_ert` (stage) — **onboarding** (DT-561 Phase 1)
 - `committee_persisting`, `define_uncooked` — `el_ministry_managed_domains` — pending (later phase)
 - `crossing_accidental` — `el_ert` (prod) — pending (later phase)
 - `furniture_magnanimous` — `el_staff_accounting_uat` — pending
@@ -218,9 +218,9 @@ Fivetran-native. Audit of active `postgres_rds` connectors and their DOT-migrati
 slot-relevant subset. Paused/dead `auto` connectors — e.g. `dawdler_managing`,
 `enter_incredulity`, `quicken_wow` — are not migration targets.)
 
-This is a separate workstream. `global-registry-prod` (`centralized_mitigation`) — which the
-valve depended on — was migrated to DOT scheduling on 2026-07-22; the remaining `auto` connectors
-above migrate connector-by-connector as each is onboarded to the valve (DT-561 rollout phases).
+This is a separate workstream. `global-registry-prod` (`centralized_mitigation`) is DOT-scheduled;
+the remaining `auto` connectors above migrate connector-by-connector as each is onboarded to the
+valve (DT-561 rollout phases).
 
 ## 9. Decisions (resolved in review, 2026-06-18)
 
@@ -247,8 +247,8 @@ Remaining work is the implementation outline below (Section 10).
 - [ ] Test: drive a slot toward the trigger (or simulate it) → mechanism force-syncs → slot
       drains; verify the already-syncing, paused-resume, and broken-stop branches.
 - [ ] Runbook note (DSE side): what the broken-connector failure signal means and how to act.
-- [~] Migrate the Fivetran-native (`auto`) connectors to DOT scheduling (Section 8) — the valve's
-      `centralized_mitigation` (`global-registry-prod`) migrated 2026-07-22; the rest migrate
-      per-connector as each is onboarded (DT-561 phases), in progress.
+- [~] Migrate the Fivetran-native (`auto`) connectors to DOT scheduling (Section 8) —
+      `centralized_mitigation` (`global-registry-prod`) is done; the rest migrate per-connector as
+      each is onboarded (DT-561 phases), in progress.
 - [ ] After the valve is proven: reduce `sync_frequency` to **daily**, each connector's run
       placed **outside its high-churn window** (Section 7).

--- a/fivetran-slot-valve/main.py
+++ b/fivetran-slot-valve/main.py
@@ -15,13 +15,13 @@ PUBSUB_TOPIC = "fivetran-slot-valve-events"
 # See dot docs/DESIGN_fivetran_slot_safety_valve.md Section 4. Only the active
 # connector per instance is a valid drain target; the paused "dead twin"
 # connectors that share each schema are intentionally excluded.
+# Adding or removing an instance here also requires the matching entry in cru-terraform
+# dot/prod/datadog.tf `fivetran_valve_daily_connectors`: a valve monitor with no mapping
+# here returns 422 and never drains.
 INSTANCE_TO_CONNECTOR = {
     "mpdx-api-prod": "loft_unabashed",  # el_mpdx
     "global-registry-prod": "centralized_mitigation",  # el_global_registry
     "global-registry-flat-prod": "freebee_tuberculosis",  # el_global_registry_flat
-    # Adding or removing an instance here also requires the matching entry in cru-terraform
-    # dot/prod/datadog.tf `fivetran_valve_daily_connectors`: a valve monitor with no mapping here
-    # returns 422 and never drains.
     "summer-missions-prod": "entrench_security",  # el_summer_missions
     "staff-accounting-app-prod": "chairmanship_bestowing",  # el_staff_accounting
     "ert-stage": "communal_whoops",  # el_ert (stage)

--- a/fivetran-slot-valve/main.py
+++ b/fivetran-slot-valve/main.py
@@ -19,6 +19,11 @@ INSTANCE_TO_CONNECTOR = {
     "mpdx-api-prod": "loft_unabashed",  # el_mpdx
     "global-registry-prod": "centralized_mitigation",  # el_global_registry
     "global-registry-flat-prod": "freebee_tuberculosis",  # el_global_registry_flat
+    # DT-561 Phase 1 (cru-terraform #11479). Must stay in sync with the
+    # fivetran_valve_daily_connectors map in cru-terraform dot/prod/datadog.tf.
+    "summer-missions-prod": "entrench_security",  # el_summer_missions
+    "staff-accounting-app-prod": "chairmanship_bestowing",  # el_staff_accounting
+    "ert-stage": "communal_whoops",  # el_ert (stage)
 }
 
 # Datadog alert transitions that should NOT trigger a drain. Everything else

--- a/fivetran-slot-valve/main.py
+++ b/fivetran-slot-valve/main.py
@@ -11,7 +11,6 @@ logger.propagate = False
 
 PUBSUB_TOPIC = "fivetran-slot-valve-events"
 
-# Reviewed RDS instance (dbinstanceidentifier) -> active Fivetran connector_id.
 # See dot docs/DESIGN_fivetran_slot_safety_valve.md Section 4. Only the active
 # connector per instance is a valid drain target; the paused "dead twin"
 # connectors that share each schema are intentionally excluded.

--- a/fivetran-slot-valve/main.py
+++ b/fivetran-slot-valve/main.py
@@ -19,8 +19,9 @@ INSTANCE_TO_CONNECTOR = {
     "mpdx-api-prod": "loft_unabashed",  # el_mpdx
     "global-registry-prod": "centralized_mitigation",  # el_global_registry
     "global-registry-flat-prod": "freebee_tuberculosis",  # el_global_registry_flat
-    # Kept in sync with the fivetran_valve_daily_connectors map in cru-terraform
-    # dot/prod/datadog.tf: a monitor there without an entry here 422s -> inert valve. (DT-561)
+    # Adding or removing an instance here also requires the matching entry in cru-terraform
+    # dot/prod/datadog.tf `fivetran_valve_daily_connectors`: a valve monitor with no mapping here
+    # returns 422 and never drains.
     "summer-missions-prod": "entrench_security",  # el_summer_missions
     "staff-accounting-app-prod": "chairmanship_bestowing",  # el_staff_accounting
     "ert-stage": "communal_whoops",  # el_ert (stage)

--- a/fivetran-slot-valve/main.py
+++ b/fivetran-slot-valve/main.py
@@ -19,8 +19,8 @@ INSTANCE_TO_CONNECTOR = {
     "mpdx-api-prod": "loft_unabashed",  # el_mpdx
     "global-registry-prod": "centralized_mitigation",  # el_global_registry
     "global-registry-flat-prod": "freebee_tuberculosis",  # el_global_registry_flat
-    # DT-561 Phase 1 (cru-terraform #11479). Must stay in sync with the
-    # fivetran_valve_daily_connectors map in cru-terraform dot/prod/datadog.tf.
+    # Kept in sync with the fivetran_valve_daily_connectors map in cru-terraform
+    # dot/prod/datadog.tf: a monitor there without an entry here 422s -> inert valve. (DT-561)
     "summer-missions-prod": "entrench_security",  # el_summer_missions
     "staff-accounting-app-prod": "chairmanship_bestowing",  # el_staff_accounting
     "ert-stage": "communal_whoops",  # el_ert (stage)

--- a/fivetran-slot-valve/main_test.py
+++ b/fivetran-slot-valve/main_test.py
@@ -96,6 +96,25 @@ def test_global_registry_flat_maps_to_correct_connector(mock_publisher):
     assert message["connector_id"] == "freebee_tuberculosis"
 
 
+@pytest.mark.parametrize(
+    "instance,connector_id",
+    [
+        ("summer-missions-prod", "entrench_security"),
+        ("staff-accounting-app-prod", "chairmanship_bestowing"),
+        ("ert-stage", "communal_whoops"),
+    ],
+)
+def test_phase1_instances_map_to_correct_connector(
+    mock_publisher, instance, connector_id
+):
+    response = main.valve_handler(_request(payload=_payload(instance=instance)))
+
+    assert response[1] == 200
+    _, published_bytes = mock_publisher.publish.call_args[0]
+    message = json.loads(published_bytes.decode("utf-8"))
+    assert message["connector_id"] == connector_id
+
+
 def test_tags_provided_as_list(mock_publisher):
     payload = _payload()
     payload["tags"] = [


### PR DESCRIPTION
## Why

Fixes a cross-repo gap caught in review of cru-terraform PR #11479 (DT-561 Phase 1). #11479 adds Datadog slot-valve + sync-recency monitors for three more RDS instances (`summer-missions-prod`, `staff-accounting-app-prod`, `ert-stage`) and moves their Fivetran connectors to DOT-scheduled daily syncs. But the slot-valve drain webhook (this `fivetran-slot-valve` function) resolves `dbinstanceidentifier → connector_id` via `INSTANCE_TO_CONNECTOR` and returns `422 "No connector mapping"` for any instance not in the map — publishing no drain event. Without this change those three monitors would fire but the valve would be **inert** (silent, zero protection), while #11479 has removed the frequent syncs that incidentally kept WAL drained.

## What changed

- `fivetran-slot-valve/main.py`: add the three active connectors to `INSTANCE_TO_CONNECTOR` (mirroring #11479's `fivetran_valve_daily_connectors`).
- `fivetran-slot-valve/main_test.py`: parametrized mapping test for all three.
- `docs/DESIGN_fivetran_slot_safety_valve.md`: add the three to the Section-4 instance→connector table; refresh the now-stale `global-registry-prod` references in Sections 4/8/10 (it flipped auto→manual on 2026-07-22 but the doc still listed it as a pending migration).

## ⚠️ Deploy ordering — must land first

This PR must **merge AND deploy** (the Cloud Function redeploys on push to `main` via `build-deploy-cloudrun-fivetran-slot-valve.yml`) **before cru-terraform #11479 applies.** If #11479's monitors go live first, they fire and the webhook 422s → inert valve. If this deploys first, the map entries are simply unexercised until #11479 lands (harmless).

## 🤖 AI-generated review

Produced by **Claude** (automated, pre-PR, via `/infra-persona-review`) — not human sign-off; still needs review.
- **Orchestration (adversarial cross-repo trace):** approve — traced all 12 hops of the drain path (monitor → webhook → gateway → secret → CF map → Pub/Sub → Eventarc → drain workflow → Fivetran API auth → IAM → DOT scheduling); the `INSTANCE_TO_CONNECTOR` map was the *only* dot-side per-instance gap, every other hop is generic or account-scoped, and #11479 covers the cru-terraform per-instance maps. Correctly excluded from `connector_to_dbt_mapping` (pure-valve, no dbt trigger). No second gap.
- **Governance:** approve — code/test/conventions clean and lint-clean; flagged (and this PR fixes) the gr-prod doc staleness in Sections 4/8/10.
- **DevOps / SRE / Security:** inline-N/A — no Terraform, IAM, secrets, or runtime-behavior change (a Python dict entry + test + doc); deploy is the existing on-merge workflow.

## Test plan

- [x] 15/15 unit tests pass locally (venv w/ requirements.txt + requirements-test.txt), incl. the 3 new parametrized cases.
- [x] Connector IDs verified against #11479's `fivetran_valve_daily_connectors` + the `staff_accounting` terraform import block; `communal_whoops` confirmed as the active `el_ert` **stage** connector via the Fivetran API (`crossing_accidental` = prod).
- [ ] Merge + deploy this, then apply #11479 (ordering above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
