### PR TITLE
ci: deploy to staging-legacy GitHub environment

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-dbt-classify.yml
+++ b/.github/workflows/build-deploy-cloudrun-dbt-classify.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: dbt-classify
       entry_point: classify_run
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-dbt-trigger.yml
+++ b/.github/workflows/build-deploy-cloudrun-dbt-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: dbt-trigger
       entry_point: trigger_dbt_job
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-dbt-webhook.yml
+++ b/.github/workflows/build-deploy-cloudrun-dbt-webhook.yml
@@ -13,5 +13,5 @@ jobs:
       function_name: dbt-webhook
       entry_point: webhook_handler
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets: inherit

--- a/.github/workflows/build-deploy-cloudrun-fivetran-slot-valve.yml
+++ b/.github/workflows/build-deploy-cloudrun-fivetran-slot-valve.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: fivetran-slot-valve
       entry_point: valve_handler
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-fivetran-trigger.yml
+++ b/.github/workflows/build-deploy-cloudrun-fivetran-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: fivetran-trigger
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-fivetran-webhook.yml
+++ b/.github/workflows/build-deploy-cloudrun-fivetran-webhook.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: fivetran-webhook
       entry_point: webhook_handler
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-okta-sync.yml
+++ b/.github/workflows/build-deploy-cloudrun-okta-sync.yml
@@ -17,7 +17,7 @@ jobs:
       job_name: okta-sync
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-process-geography.yml
+++ b/.github/workflows/build-deploy-cloudrun-process-geography.yml
@@ -17,7 +17,7 @@ jobs:
       job_name: process-geography
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-woo-sync.yml
+++ b/.github/workflows/build-deploy-cloudrun-woo-sync.yml
@@ -17,7 +17,7 @@ jobs:
       job_name: woo-sync
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}


### PR DESCRIPTION
## Summary

Points the `environment:` ternary in all 9 `build-deploy-cloudrun-*` workflows at `staging-legacy` instead of `staging`. `production` and `poc` untouched; the branch condition stays `refs/heads/staging`.

**Why:** dot is migrating to the new `gcp/cloudrun/app` platform module, which will create a fresh GitHub environment named `staging` on this repo. The legacy stage terraform must vacate that name first and is being renamed to `staging-legacy` (which carries the existing 7 `GCP_*` / `WORKLOAD_IDENTITY_*` variables), so CI has to follow.

## Paired PR

CruGlobal/cru-terraform#11722 — renames the environment + its 7 variables.

Land back-to-back with that one. A brief window where staging deploys can't resolve their environment is acceptable.

Follow-up: this same edit must also land on the `staging` branch of this repo, since Actions runs the workflow file from the pushed branch — merging to `main` alone does not change what a push to `staging` executes.