### PR TITLE
Use staging-legacy GitHub environment for staging deploys

### DIFF
--- a/.github/workflows/build-deploy-cloudrun-dbt-trigger.yml
+++ b/.github/workflows/build-deploy-cloudrun-dbt-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: dbt-trigger
       entry_point: trigger_dbt_job
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-dbt-webhook.yml
+++ b/.github/workflows/build-deploy-cloudrun-dbt-webhook.yml
@@ -13,5 +13,5 @@ jobs:
       function_name: dbt-webhook
       entry_point: webhook_handler
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets: inherit

--- a/.github/workflows/build-deploy-cloudrun-fivetran-trigger.yml
+++ b/.github/workflows/build-deploy-cloudrun-fivetran-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: fivetran-trigger
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-fivetran-webhook.yml
+++ b/.github/workflows/build-deploy-cloudrun-fivetran-webhook.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: fivetran-webhook
       entry_point: webhook_handler
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-google-sheets-trigger.yml
+++ b/.github/workflows/build-deploy-cloudrun-google-sheets-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       function_name: google-sheets-trigger
       entry_point: trigger_sheets_check
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-okta-sync.yml
+++ b/.github/workflows/build-deploy-cloudrun-okta-sync.yml
@@ -17,7 +17,7 @@ jobs:
       job_name: okta-sync
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-process-geography.yml
+++ b/.github/workflows/build-deploy-cloudrun-process-geography.yml
@@ -17,7 +17,7 @@ jobs:
       job_name: process-geography
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}

--- a/.github/workflows/build-deploy-cloudrun-woo-sync.yml
+++ b/.github/workflows/build-deploy-cloudrun-woo-sync.yml
@@ -17,7 +17,7 @@ jobs:
       job_name: woo-sync
       entry_point: trigger_sync
       runtime: python312
-      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging' }}
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.ref == 'refs/heads/poc' && 'poc' || github.ref == 'refs/heads/staging' && 'staging-legacy' }}
     secrets:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_PROJECT_NUMBER: ${{ vars.GCP_PROJECT_NUMBER }}


### PR DESCRIPTION
## Summary
Staging-branch twin of #119: same `'staging'` → `'staging-legacy'` edit in the 8 deploy workflows that exist on this branch (including the staging-only `google-sheets-trigger`). Workflows run from the pushed branch's copy, so #119 (main) alone does not cover deploys from `staging`.

Merge order: land after cru-terraform#11722 applies (which creates the `staging-legacy` environment + variables); merging before it would leave staging deploys pointing at a not-yet-existing environment.

Deliberately a targeted commit on top of `origin/staging` — not a merge from main — to avoid entangling this rename with the branch divergence (4 ahead / 91 behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)